### PR TITLE
refactor: 유저 로그인/회원가입

### DIFF
--- a/src/main/java/com/ceos/bankids/config/CommonControllerAdvice.java
+++ b/src/main/java/com/ceos/bankids/config/CommonControllerAdvice.java
@@ -41,6 +41,7 @@ public class CommonControllerAdvice {
     public ResponseEntity onException(Exception exception, @AuthenticationPrincipal User user,
         HttpServletRequest request) {
         getExceptionStackTrace(exception, user, request);
+        exception.printStackTrace();
         return new ResponseEntity<>(CommonResponse.onFailure("서버 에러가 발생했습니다."), null,
             HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/com/ceos/bankids/controller/KakaoController.java
+++ b/src/main/java/com/ceos/bankids/controller/KakaoController.java
@@ -2,31 +2,20 @@ package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.KakaoRequest;
-import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.LoginDTO;
-import com.ceos.bankids.dto.TokenDTO;
 import com.ceos.bankids.dto.oauth.KakaoTokenDTO;
 import com.ceos.bankids.dto.oauth.KakaoUserDTO;
-import com.ceos.bankids.exception.BadRequestException;
-import com.ceos.bankids.repository.UserRepository;
-import com.ceos.bankids.service.JwtTokenServiceImpl;
+import com.ceos.bankids.service.KakaoServiceImpl;
 import io.swagger.annotations.ApiOperation;
-import java.util.Optional;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 @Log
 @Controller
@@ -34,14 +23,8 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class KakaoController {
 
-    private final UserRepository uRepo;
-    private final WebClient webClient;
-    private final JwtTokenServiceImpl jwtTokenServiceImpl;
+    private final KakaoServiceImpl kakaoService;
 
-    @Value("${kakao.key}")
-    private String KAKAO_KEY;
-    @Value("${kakao.uri}")
-    private String KAKAO_URI;
 
     @ApiOperation(value = "카카오 로그인")
     @PostMapping(value = "/login", produces = "application/json; charset=utf-8")
@@ -49,69 +32,12 @@ public class KakaoController {
     public CommonResponse<LoginDTO> postKakaoLogin(@Valid @RequestBody KakaoRequest kakaoRequest,
         HttpServletResponse response) {
 
-        String getTokenURL =
-            "https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id="
-                + KAKAO_KEY + "&redirect_uri=" + KAKAO_URI + "&code="
-                + kakaoRequest.getCode();
+        KakaoTokenDTO kakaoTokenDTO = kakaoService.getKakaoAccessToken(kakaoRequest);
 
-        KakaoTokenDTO kakaoTokenDTO = (KakaoTokenDTO) webClient.post().uri(getTokenURL).retrieve()
-            .onStatus(HttpStatus::is4xxClientError,
-                clientResponse -> Mono.error(new BadRequestException("잘못된 요청입니다.")))
-            .bodyToMono(
-                ParameterizedTypeReference.forType(KakaoTokenDTO.class))
-            .block();
+        KakaoUserDTO kakaoUserDTO = kakaoService.getKakaoUserCode(kakaoTokenDTO);
 
-        String getUserURL = "https://kapi.kakao.com/v2/user/me";
+        LoginDTO loginDTO = kakaoService.loginWithAuthenticationCode(kakaoUserDTO, response);
 
-        KakaoUserDTO kakaoUserDTO = (KakaoUserDTO) webClient.post().uri(getUserURL)
-            .header("Authorization", "Bearer " + kakaoTokenDTO.getAccessToken())
-            .retrieve()
-            .onStatus(HttpStatus::is4xxClientError,
-                clientResponse -> Mono.error(new BadRequestException("잘못된 요청입니다.")))
-            .bodyToMono(
-                ParameterizedTypeReference.forType(KakaoUserDTO.class))
-            .block();
-
-        Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
-        if (user.isPresent()) {
-            TokenDTO tokenDTO = new TokenDTO(user.get());
-            Cookie cookie = new Cookie("refreshToken", user.get().getRefreshToken());
-
-            cookie.setMaxAge(14 * 24 * 60 * 60);
-            cookie.setSecure(true);
-            cookie.setHttpOnly(true);
-            cookie.setPath("/");
-
-            response.addCookie(cookie);
-
-            LoginDTO loginDTO = new LoginDTO(true, user.get().getIsKid(),
-                jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
-            return CommonResponse.onSuccess(loginDTO);
-        } else {
-            User newUser = User.builder()
-                .username(kakaoUserDTO.getKakaoAccount().getProfile().getNickname())
-                .authenticationCode(kakaoUserDTO.getAuthenticationCode())
-                .provider("kakao").refreshToken("")
-                .build();
-            uRepo.save(newUser);
-
-            String refreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(newUser.getId());
-            newUser.setRefreshToken(refreshToken);
-            uRepo.save(newUser);
-
-            Cookie cookie = new Cookie("refreshToken", refreshToken);
-
-            cookie.setMaxAge(14 * 24 * 60 * 60);
-            cookie.setSecure(true);
-            cookie.setHttpOnly(true);
-            cookie.setPath("/");
-
-            response.addCookie(cookie);
-
-            TokenDTO tokenDTO = new TokenDTO(newUser);
-            LoginDTO loginDTO = new LoginDTO(false, null,
-                jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
-            return CommonResponse.onSuccess(loginDTO);
-        }
+        return CommonResponse.onSuccess(loginDTO);
     }
 }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -2,16 +2,10 @@ package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.UserTypeRequest;
-import com.ceos.bankids.domain.Kid;
-import com.ceos.bankids.domain.Parent;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.UserDTO;
-import com.ceos.bankids.exception.BadRequestException;
-import com.ceos.bankids.repository.KidRepository;
-import com.ceos.bankids.repository.ParentRepository;
-import com.ceos.bankids.repository.UserRepository;
+import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
-import java.util.Optional;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
@@ -28,9 +22,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserRepository uRepo;
-    private final KidRepository kRepo;
-    private final ParentRepository pRepo;
+    private final UserServiceImpl userService;
 
     @ApiOperation(value = "유저 타입 선택")
     @PatchMapping(value = "", produces = "application/json; charset=utf-8")
@@ -38,31 +30,7 @@ public class UserController {
     public CommonResponse<UserDTO> patchUserType(@AuthenticationPrincipal User authUser,
         @Valid @RequestBody UserTypeRequest userTypeRequest) {
 
-        Long userId = authUser.getId();
-        Optional<User> user = uRepo.findById(userId);
-
-        if (user.isEmpty()) {
-            throw new BadRequestException("존재하지 않는 유저입니다.");
-        } else {
-            user.get().setIsFemale(userTypeRequest.getIsFemale());
-            user.get().setIsKid(userTypeRequest.getIsKid());
-            uRepo.save(user.get());
-
-            if (user.get().getIsKid()) {
-                Kid newKid = Kid.builder()
-                    .savings(0L)
-                    .user(user.get())
-                    .build();
-                kRepo.save(newKid);
-            } else {
-                Parent newParent = Parent.builder()
-                    .user(user.get())
-                    .build();
-                pRepo.save(newParent);
-            }
-
-            UserDTO userDTO = new UserDTO(user.get());
-            return CommonResponse.onSuccess(userDTO);
-        }
+        UserDTO userDTO = userService.updateUserType(authUser, userTypeRequest);
+        return CommonResponse.onSuccess(userDTO);
     }
 }

--- a/src/main/java/com/ceos/bankids/service/KakaoService.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoService.java
@@ -1,0 +1,19 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.controller.request.KakaoRequest;
+import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.oauth.KakaoTokenDTO;
+import com.ceos.bankids.dto.oauth.KakaoUserDTO;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface KakaoService {
+
+    public KakaoTokenDTO getKakaoAccessToken(KakaoRequest kakaoRequest);
+
+    public KakaoUserDTO getKakaoUserCode(KakaoTokenDTO kakaoTokenDTO);
+
+    public LoginDTO loginWithAuthenticationCode(KakaoUserDTO kakaoUserDTO,
+        HttpServletResponse response);
+}

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -35,6 +35,7 @@ public class KakaoServiceImpl implements KakaoService {
     private String KAKAO_URI;
 
     @Override
+    @Transactional
     public KakaoTokenDTO getKakaoAccessToken(KakaoRequest kakaoRequest) {
         String getTokenURL =
             "https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id="
@@ -50,6 +51,7 @@ public class KakaoServiceImpl implements KakaoService {
     }
 
     @Override
+    @Transactional
     public KakaoUserDTO getKakaoUserCode(KakaoTokenDTO kakaoTokenDTO) {
         String getUserURL = "https://kapi.kakao.com/v2/user/me";
 
@@ -64,6 +66,7 @@ public class KakaoServiceImpl implements KakaoService {
     }
 
     @Override
+    @Transactional
     public LoginDTO loginWithAuthenticationCode(KakaoUserDTO kakaoUserDTO,
         HttpServletResponse response) {
         Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -1,0 +1,111 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.controller.request.KakaoRequest;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.TokenDTO;
+import com.ceos.bankids.dto.oauth.KakaoTokenDTO;
+import com.ceos.bankids.dto.oauth.KakaoUserDTO;
+import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.repository.UserRepository;
+import java.util.Optional;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = false)
+public class KakaoServiceImpl implements KakaoService {
+
+    private final UserRepository uRepo;
+    private final JwtTokenServiceImpl jwtTokenServiceImpl;
+    private final WebClient webClient;
+
+    @Value("${kakao.key}")
+    private String KAKAO_KEY;
+    @Value("${kakao.uri}")
+    private String KAKAO_URI;
+
+    @Override
+    public KakaoTokenDTO getKakaoAccessToken(KakaoRequest kakaoRequest) {
+        String getTokenURL =
+            "https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id="
+                + KAKAO_KEY + "&redirect_uri=" + KAKAO_URI + "&code="
+                + kakaoRequest.getCode();
+
+        return (KakaoTokenDTO) webClient.post().uri(getTokenURL).retrieve()
+            .onStatus(HttpStatus::is4xxClientError,
+                clientResponse -> Mono.error(new BadRequestException("잘못된 요청입니다.")))
+            .bodyToMono(
+                ParameterizedTypeReference.forType(KakaoTokenDTO.class))
+            .block();
+    }
+
+    @Override
+    public KakaoUserDTO getKakaoUserCode(KakaoTokenDTO kakaoTokenDTO) {
+        String getUserURL = "https://kapi.kakao.com/v2/user/me";
+
+        return (KakaoUserDTO) webClient.post().uri(getUserURL)
+            .header("Authorization", "Bearer " + kakaoTokenDTO.getAccessToken())
+            .retrieve()
+            .onStatus(HttpStatus::is4xxClientError,
+                clientResponse -> Mono.error(new BadRequestException("잘못된 요청입니다.")))
+            .bodyToMono(
+                ParameterizedTypeReference.forType(KakaoUserDTO.class))
+            .block();
+    }
+
+    @Override
+    public LoginDTO loginWithAuthenticationCode(KakaoUserDTO kakaoUserDTO,
+        HttpServletResponse response) {
+        Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
+        if (user.isPresent()) {
+            TokenDTO tokenDTO = new TokenDTO(user.get());
+            Cookie cookie = new Cookie("refreshToken", user.get().getRefreshToken());
+
+            cookie.setMaxAge(14 * 24 * 60 * 60);
+            cookie.setSecure(true);
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+
+            response.addCookie(cookie);
+
+            LoginDTO loginDTO = new LoginDTO(true, user.get().getIsKid(),
+                jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
+            return loginDTO;
+        } else {
+            User newUser = User.builder()
+                .username(kakaoUserDTO.getKakaoAccount().getProfile().getNickname())
+                .authenticationCode(kakaoUserDTO.getAuthenticationCode())
+                .provider("kakao").refreshToken("")
+                .build();
+            uRepo.save(newUser);
+
+            String refreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(newUser.getId());
+            newUser.setRefreshToken(refreshToken);
+            uRepo.save(newUser);
+
+            Cookie cookie = new Cookie("refreshToken", refreshToken);
+
+            cookie.setMaxAge(14 * 24 * 60 * 60);
+            cookie.setSecure(true);
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+
+            response.addCookie(cookie);
+
+            TokenDTO tokenDTO = new TokenDTO(newUser);
+            LoginDTO loginDTO = new LoginDTO(false, null,
+                jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
+            return loginDTO;
+        }
+    }
+}

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -1,0 +1,16 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.controller.request.UserTypeRequest;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.UserDTO;
+import javax.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Service
+public interface UserService {
+
+    public UserDTO updateUserType(@AuthenticationPrincipal User authUser,
+        @Valid @RequestBody UserTypeRequest userTypeRequest);
+}

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = false)
 public class UserServiceImpl implements UserService {
 
     private final UserRepository uRepo;
@@ -27,6 +26,7 @@ public class UserServiceImpl implements UserService {
     private final ParentRepository pRepo;
 
     @Override
+    @Transactional
     public UserDTO updateUserType(@AuthenticationPrincipal User authUser,
         @Valid @RequestBody UserTypeRequest userTypeRequest) {
         Long userId = authUser.getId();

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -1,0 +1,57 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.controller.request.UserTypeRequest;
+import com.ceos.bankids.domain.Kid;
+import com.ceos.bankids.domain.Parent;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.UserDTO;
+import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.repository.KidRepository;
+import com.ceos.bankids.repository.ParentRepository;
+import com.ceos.bankids.repository.UserRepository;
+import java.util.Optional;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = false)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository uRepo;
+    private final KidRepository kRepo;
+    private final ParentRepository pRepo;
+
+    @Override
+    public UserDTO updateUserType(@AuthenticationPrincipal User authUser,
+        @Valid @RequestBody UserTypeRequest userTypeRequest) {
+        Long userId = authUser.getId();
+        Optional<User> user = uRepo.findById(userId);
+        if (user.isEmpty()) {
+            throw new BadRequestException("존재하지 않는 유저입니다.");
+        } else {
+            user.get().setIsFemale(userTypeRequest.getIsFemale());
+            user.get().setIsKid(userTypeRequest.getIsKid());
+            uRepo.save(user.get());
+
+            if (user.get().getIsKid()) {
+                Kid newKid = Kid.builder()
+                    .savings(0L)
+                    .user(user.get())
+                    .build();
+                kRepo.save(newKid);
+            } else {
+                Parent newParent = Parent.builder()
+                    .user(user.get())
+                    .build();
+                pRepo.save(newParent);
+            }
+            UserDTO userDTO = new UserDTO(user.get());
+            return userDTO;
+        }
+    }
+}

--- a/src/test/java/com/ceos/bankids/unit/controller/KakaoControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/KakaoControllerTest.java
@@ -4,6 +4,7 @@ import com.ceos.bankids.controller.KakaoController;
 import com.ceos.bankids.controller.request.KakaoRequest;
 import com.ceos.bankids.repository.UserRepository;
 import com.ceos.bankids.service.JwtTokenServiceImpl;
+import com.ceos.bankids.service.KakaoServiceImpl;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -23,10 +24,13 @@ public class KakaoControllerTest {
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
 
         // when
-        KakaoController kakaoController = new KakaoController(
+        KakaoServiceImpl kakaoService = new KakaoServiceImpl(
             mockUserRepository,
-            mockWebClient,
-            jwtTokenServiceImpl
+            jwtTokenServiceImpl,
+            mockWebClient
+        );
+        KakaoController kakaoController = new KakaoController(
+            kakaoService
         );
 
         // then
@@ -46,10 +50,13 @@ public class KakaoControllerTest {
         KakaoRequest kakaoRequest = new KakaoRequest("code");
 
         // when
-        KakaoController kakaoController = new KakaoController(
+        KakaoServiceImpl kakaoService = new KakaoServiceImpl(
             mockUserRepository,
-            mockWebClient,
-            jwtTokenServiceImpl
+            jwtTokenServiceImpl,
+            mockWebClient
+        );
+        KakaoController kakaoController = new KakaoController(
+            kakaoService
         );
 
         // then

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.repository.KidRepository;
 import com.ceos.bankids.repository.ParentRepository;
 import com.ceos.bankids.repository.UserRepository;
+import com.ceos.bankids.service.UserServiceImpl;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -42,10 +43,13 @@ public class UserControllerTest {
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
 
         // when
-        UserController userController = new UserController(
+        UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
             mockParentRepository
+        );
+        UserController userController = new UserController(
+            userService
         );
         CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
 
@@ -78,10 +82,13 @@ public class UserControllerTest {
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
 
         // when
-        UserController userController = new UserController(
+        UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
             mockParentRepository
+        );
+        UserController userController = new UserController(
+            userService
         );
 
         // then
@@ -112,10 +119,13 @@ public class UserControllerTest {
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
 
         // when
-        UserController userController = new UserController(
+        UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
             mockParentRepository
+        );
+        UserController userController = new UserController(
+            userService
         );
 
         // then
@@ -152,10 +162,13 @@ public class UserControllerTest {
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
 
         // when
-        UserController userController = new UserController(
+        UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
             mockParentRepository
+        );
+        UserController userController = new UserController(
+            userService
         );
         CommonResponse result = userController.patchUserType(user, userTypeRequest);
 
@@ -202,10 +215,13 @@ public class UserControllerTest {
         Mockito.when(mockParentRepository.save(parent)).thenReturn(parent);
 
         // when
-        UserController userController = new UserController(
+        UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
             mockParentRepository
+        );
+        UserController userController = new UserController(
+            userService
         );
         CommonResponse result = userController.patchUserType(user, userTypeRequest);
 


### PR DESCRIPTION
## 📝 PR Summary
카카오 로그인, 유저 타입 선택 API에 대하여
Controller 계층은 클라이언트의 요청만 처리하고 Service에서 Repository에 정의된 비즈니스 로직을 처리하도록 변경
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
refactor/userLogin
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] 카카오 로그인 API 리팩토링
- [x] 유저 타입 선택 API 리팩토링
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#11
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
