### PR TITLE
feat: Challenge 포기 API 작성 / Challenge 관련 API들 Test 완료

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/ChallengeController.java
+++ b/src/main/java/com/ceos/bankids/controller/ChallengeController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,7 +41,17 @@ public class ChallengeController {
     public CommonResponse<ChallengeDTO> getChallenge(@AuthenticationPrincipal User authUser,
         @PathVariable Long challengeId) {
 
-        ChallengeDTO challengeDTO = challengeService.detailChallenge(challengeId);
+        ChallengeDTO challengeDTO = challengeService.detailChallenge(authUser, challengeId);
+
+        return CommonResponse.onSuccess(challengeDTO);
+    }
+
+    @ApiOperation(value = "돈길 포기하기")
+    @DeleteMapping(value = "/{challengeId}", produces = "application/json; charset=utf-8")
+    public CommonResponse<ChallengeDTO> deleteChallenge(@AuthenticationPrincipal User authUser,
+        @PathVariable Long challengeId) {
+
+        ChallengeDTO challengeDTO = challengeService.deleteChallenge(authUser, challengeId);
 
         return CommonResponse.onSuccess(challengeDTO);
     }

--- a/src/main/java/com/ceos/bankids/repository/ChallengeUserRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/ChallengeUserRepository.java
@@ -1,11 +1,12 @@
 package com.ceos.bankids.repository;
 
 import com.ceos.bankids.domain.ChallengeUser;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChallengeUserRepository extends JpaRepository<ChallengeUser, Long> {
 
     public Optional<ChallengeUser> findByChallengeId(Long challengeId);
+
+    public Optional<ChallengeUser> findByUserId(Long userId);
 }

--- a/src/main/java/com/ceos/bankids/repository/ProgressRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/ProgressRepository.java
@@ -1,0 +1,11 @@
+package com.ceos.bankids.repository;
+
+import com.ceos.bankids.domain.Progress;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProgressRepository extends JpaRepository<Progress, Long> {
+
+    public Optional<Progress> findByChallengeId(Long challengeId);
+
+}

--- a/src/main/java/com/ceos/bankids/service/ChallengeService.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeService.java
@@ -10,6 +10,8 @@ public interface ChallengeService {
 
     public ChallengeDTO createChallenge(User user, ChallengeRequest challengeRequest);
 
-    public ChallengeDTO detailChallenge(Long challengeId);
+    public ChallengeDTO detailChallenge(User user, Long challengeId);
+
+    public ChallengeDTO deleteChallenge(User user, Long challengeId);
 
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -8,11 +8,13 @@ import com.ceos.bankids.domain.TargetItem;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.ChallengeDTO;
 import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.exception.ForbiddenException;
 import com.ceos.bankids.exception.NotFoundException;
 import com.ceos.bankids.repository.ChallengeCategoryRepository;
 import com.ceos.bankids.repository.ChallengeRepository;
 import com.ceos.bankids.repository.ChallengeUserRepository;
 import com.ceos.bankids.repository.TargetItemRepository;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,17 +66,39 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Transactional
     @Override
-    public ChallengeDTO detailChallenge(Long challengeId) {
+    public ChallengeDTO detailChallenge(User user, Long challengeId) {
         Optional<ChallengeUser> challengeUserRow = challengeUserRepository.findByChallengeId(
             challengeId);
+        System.out.println(user.getId());
         if (challengeUserRow.isPresent()) {
             ChallengeUser challengeUser = challengeUserRow.get();
+            if (!Objects.equals(challengeUser.getUser().getId(), user.getId())) {
+                throw new ForbiddenException("권한이 없습니다.");
+            }
             Challenge findChallenge = challengeUser.getChallenge();
             return new ChallengeDTO((findChallenge));
         } else {
             throw new NotFoundException("챌린지가 없습니다.");
         }
+    }
 
+    @Transactional
+    @Override
+    public ChallengeDTO deleteChallenge(User user, Long challengeId) {
+        Optional<ChallengeUser> deleteChallengeUserRow = challengeUserRepository.findByChallengeId(
+            challengeId);
+        if (deleteChallengeUserRow.isPresent()) {
+            ChallengeUser deleteChallengeUser = deleteChallengeUserRow.get();
+            Challenge deleteChallenge = deleteChallengeUser.getChallenge();
+            if (!Objects.equals(deleteChallengeUser.getUser().getId(), user.getId())) {
+                throw new ForbiddenException("권한이 없습니다.");
+            }
+            challengeUserRepository.delete(deleteChallengeUser);
+            challengeRepository.delete(deleteChallenge);
+            return null;
+        } else {
+            throw new NotFoundException("챌린지가 없습니다.");
+        }
     }
 }
 

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -6,16 +6,22 @@ import com.ceos.bankids.controller.request.ChallengeRequest;
 import com.ceos.bankids.domain.Challenge;
 import com.ceos.bankids.domain.ChallengeCategory;
 import com.ceos.bankids.domain.ChallengeUser;
+import com.ceos.bankids.domain.Progress;
 import com.ceos.bankids.domain.TargetItem;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.ChallengeDTO;
 import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.exception.ForbiddenException;
+import com.ceos.bankids.exception.NotFoundException;
 import com.ceos.bankids.repository.ChallengeCategoryRepository;
 import com.ceos.bankids.repository.ChallengeRepository;
 import com.ceos.bankids.repository.ChallengeUserRepository;
+import com.ceos.bankids.repository.ProgressRepository;
 import com.ceos.bankids.repository.TargetItemRepository;
 import com.ceos.bankids.repository.UserRepository;
 import com.ceos.bankids.service.ChallengeServiceImpl;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +43,7 @@ public class ChallengeControllerTest {
         ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
         //given
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
@@ -90,7 +97,8 @@ public class ChallengeControllerTest {
             mockChallengeRepository,
             mockChallengeCategoryRepository,
             mockTargetItemRepository,
-            mockChallengeUserRepository
+            mockChallengeUserRepository,
+            mockProgressRepository
         );
         ChallengeController challengeController = new ChallengeController(
             challengeService
@@ -119,6 +127,7 @@ public class ChallengeControllerTest {
         ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
@@ -182,7 +191,8 @@ public class ChallengeControllerTest {
             mockChallengeRepository,
             mockChallengeCategoryRepository,
             mockTargetItemRepository,
-            mockChallengeUserRepository
+            mockChallengeUserRepository,
+            mockProgressRepository
         );
         ChallengeController challengeController = new ChallengeController(
             challengeService
@@ -205,8 +215,8 @@ public class ChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("챌린지 정보 가져오기 테스트")
-    public void testGetChallengeInfo() {
+    @DisplayName("챌린지 생성 시, 목표 아이템 입력 400 에러 테스트")
+    public void testIfMakeChallengeTargetItemBadRequestErr() {
 
         //given
         ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
@@ -215,9 +225,83 @@ public class ChallengeControllerTest {
         ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "선물", "에어팟 사기",
+            30L, 150000L, 10000L, 15L);
+
+        User newUser = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder()
+            .id(1L)
+            .category("이자율 받기")
+            .build();
+
+        TargetItem newTargetItem = TargetItem.builder()
+            .id(1L)
+            .name("전자제품")
+            .build();
+
+        Challenge newChallenge = Challenge.builder()
+            .title(challengeRequest.getTitle())
+            .isAchieved(false)
+            .totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice())
+            .weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory)
+            .targetItem(newTargetItem)
+            .status(1L)
+            .interestRate(challengeRequest.getInterestRate())
+            .build();
+        Mockito.when(mockChallengeCategoryRepository.findByCategory(
+                newChallenge.getChallengeCategory().getCategory()))
+            .thenReturn(newChallengeCategory);
+        Mockito.when(mockTargetItemRepository.findByName(newChallenge.getTargetItem().getName()))
+            .thenReturn(newTargetItem);
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
+            mockChallengeRepository,
+            mockChallengeCategoryRepository,
+            mockTargetItemRepository,
+            mockChallengeUserRepository,
+            mockProgressRepository
+        );
+        ChallengeController challengeController = new ChallengeController(
+            challengeService
+        );
+
+        //then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            challengeController.postChallenge(newUser, challengeRequest, mockBindingResult);
+        });
+    }
+
+    @Test
+    @DisplayName("챌린지 생성 시, 챌린지 카테고리 400 에러 테스트")
+    public void testIfMakeChallengeChallengeCategoryBadRequestErr() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("형제와 경쟁 하기", "전자제품", "에어팟 사기",
             30L, 150000L, 10000L, 15L);
 
         User newUser = User.builder()
@@ -253,50 +337,29 @@ public class ChallengeControllerTest {
             .interestRate(challengeRequest.getInterestRate())
             .build();
 
-        ChallengeUser newChallengeUser = ChallengeUser.builder()
-            .challenge(newChallenge)
-            .member("parent")
-            .user(newUser)
-            .build();
-
-        Mockito.when(mockChallengeRepository.save(newChallenge))
-            .thenReturn(newChallenge);
-        Mockito.when(mockChallengeRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(newChallenge));
-        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
-            .thenReturn(newTargetItem);
-        Mockito.when(
-                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
+        Mockito.when(mockChallengeCategoryRepository.findByCategory(
+                newChallenge.getChallengeCategory().getCategory()))
             .thenReturn(newChallengeCategory);
-        Mockito.when(mockChallengeUserRepository.save(newChallengeUser))
-            .thenReturn(newChallengeUser);
-        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
-            .thenReturn(Optional.ofNullable(newChallengeUser));
+        Mockito.when(mockTargetItemRepository.findByName(newChallenge.getTargetItem().getName()))
+            .thenReturn(newTargetItem);
 
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
             mockChallengeRepository,
             mockChallengeCategoryRepository,
             mockTargetItemRepository,
-            mockChallengeUserRepository
+            mockChallengeUserRepository,
+            mockProgressRepository
         );
         ChallengeController challengeController = new ChallengeController(
             challengeService
         );
-        Long challengeId = newChallenge.getId();
-        CommonResponse result = challengeController.getChallenge(newUser, challengeId);
 
         //then
-        ChallengeDTO challengeDTO = new ChallengeDTO(newChallenge);
-        ArgumentCaptor<Long> cuCaptor = ArgumentCaptor.forClass(Long.class);
-        System.out.println(cuCaptor);
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            challengeController.postChallenge(newUser, challengeRequest, mockBindingResult);
+        });
 
-        Mockito.verify(mockChallengeUserRepository, Mockito.times(1))
-            .findByChallengeId(cuCaptor.capture());
-
-        Assertions.assertEquals(newChallenge.getId(), cuCaptor.getValue());
-
-        Assertions.assertEquals(CommonResponse.onSuccess(challengeDTO), result);
     }
 
     @Test
@@ -310,6 +373,7 @@ public class ChallengeControllerTest {
         ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
@@ -348,12 +412,19 @@ public class ChallengeControllerTest {
             .interestRate(challengeRequest.getInterestRate())
             .build();
 
+        Mockito.when(mockChallengeCategoryRepository.findByCategory(
+                newChallenge.getChallengeCategory().getCategory()))
+            .thenReturn(newChallengeCategory);
+        Mockito.when(mockTargetItemRepository.findByName(newChallenge.getTargetItem().getName()))
+            .thenReturn(newTargetItem);
+
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
             mockChallengeRepository,
             mockChallengeCategoryRepository,
             mockTargetItemRepository,
-            mockChallengeUserRepository
+            mockChallengeUserRepository,
+            mockProgressRepository
         );
         ChallengeController challengeController = new ChallengeController(
             challengeService
@@ -366,5 +437,665 @@ public class ChallengeControllerTest {
 
     }
 
+    @Test
+    @DisplayName("챌린지 정보 가져오기 테스트")
+    public void testGetChallengeInfo() {
 
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
+            30L, 150000L, 10000L, 15L);
+
+        User newUser = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder()
+            .id(1L)
+            .category("이자율 받기")
+            .build();
+
+        TargetItem newTargetItem = TargetItem.builder()
+            .id(1L)
+            .name("전자제품")
+            .build();
+
+        Challenge newChallenge = Challenge.builder()
+            .title(challengeRequest.getTitle())
+            .isAchieved(false)
+            .totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice())
+            .weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory)
+            .targetItem(newTargetItem)
+            .status(1L)
+            .interestRate(challengeRequest.getInterestRate())
+            .build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder()
+            .challenge(newChallenge)
+            .member("parent")
+            .user(newUser)
+            .build();
+
+        Mockito.when(mockChallengeRepository.save(newChallenge))
+            .thenReturn(newChallenge);
+        Mockito.when(mockChallengeRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(newChallenge));
+        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
+            .thenReturn(newTargetItem);
+        Mockito.when(
+                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
+            .thenReturn(newChallengeCategory);
+        Mockito.when(mockChallengeUserRepository.save(newChallengeUser))
+            .thenReturn(newChallengeUser);
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
+            mockChallengeRepository,
+            mockChallengeCategoryRepository,
+            mockTargetItemRepository,
+            mockChallengeUserRepository,
+            mockProgressRepository
+        );
+        ChallengeController challengeController = new ChallengeController(
+            challengeService
+        );
+        Long challengeId = newChallenge.getId();
+        CommonResponse result = challengeController.getChallenge(newUser, challengeId);
+
+        //then
+        ChallengeDTO challengeDTO = new ChallengeDTO(newChallenge);
+        ArgumentCaptor<Long> cuCaptor = ArgumentCaptor.forClass(Long.class);
+
+        Mockito.verify(mockChallengeUserRepository, Mockito.times(1))
+            .findByChallengeId(cuCaptor.capture());
+
+        Assertions.assertEquals(newChallenge.getId(), cuCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(challengeDTO), result);
+    }
+
+    @Test
+    @DisplayName("챌린지 정보 조회 시, 챌린지를 생성한 유저가 아닌 경우 403 에러 테스트")
+    public void testIfNotAuthUserForDetailChallengeIsForbbiden() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
+            30L, 150000L, 10000L, 15L);
+
+        User newUser1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        User newUser2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder()
+            .id(1L)
+            .category("이자율 받기")
+            .build();
+
+        TargetItem newTargetItem = TargetItem.builder()
+            .id(1L)
+            .name("전자제품")
+            .build();
+
+        Challenge newChallenge = Challenge.builder()
+            .title(challengeRequest.getTitle())
+            .isAchieved(false)
+            .totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice())
+            .weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory)
+            .targetItem(newTargetItem)
+            .status(1L)
+            .interestRate(challengeRequest.getInterestRate())
+            .build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder()
+            .challenge(newChallenge)
+            .member("parent")
+            .user(newUser1)
+            .build();
+
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
+            mockChallengeRepository,
+            mockChallengeCategoryRepository,
+            mockTargetItemRepository,
+            mockChallengeUserRepository,
+            mockProgressRepository
+        );
+        ChallengeController challengeController = new ChallengeController(
+            challengeService
+        );
+        Long challengeId = newChallenge.getId();
+
+        //then
+        ChallengeDTO challengeDTO = new ChallengeDTO(newChallenge);
+
+        Assertions.assertThrows(ForbiddenException.class, () -> {
+            challengeController.getChallenge(newUser2, challengeId);
+        });
+    }
+
+    @Test
+    @DisplayName("챌린지 조회 시, 챌린지 아이디로 챌린지를 못찾으면 404 에러 테스트")
+    public void testIfGetChallengeIsNullNotFoundErr() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
+            30L, 150000L, 10000L, 15L);
+
+        User newUser1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder()
+            .id(1L)
+            .category("이자율 받기")
+            .build();
+
+        TargetItem newTargetItem = TargetItem.builder()
+            .id(1L)
+            .name("전자제품")
+            .build();
+
+        Challenge newChallenge = Challenge.builder()
+            .title(challengeRequest.getTitle())
+            .isAchieved(false)
+            .totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice())
+            .weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory)
+            .targetItem(newTargetItem)
+            .status(1L)
+            .interestRate(challengeRequest.getInterestRate())
+            .build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder()
+            .challenge(newChallenge)
+            .member("parent")
+            .user(newUser1)
+            .build();
+
+        Progress newProgress = Progress.builder()
+            .id(1L)
+            .weeks(1L)
+            .isAchieved(true)
+            .challenge(newChallenge)
+            .build();
+
+        Progress newProgress2 = Progress.builder()
+            .id(2L)
+            .weeks(2L)
+            .isAchieved(true)
+            .challenge(newChallenge)
+            .build();
+
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
+            mockChallengeRepository,
+            mockChallengeCategoryRepository,
+            mockTargetItemRepository,
+            mockChallengeUserRepository,
+            mockProgressRepository
+        );
+        ChallengeController challengeController = new ChallengeController(
+            challengeService
+        );
+        Long challengeId = newChallenge.getId();
+
+        //then
+        Assertions.assertThrows(NotFoundException.class, () -> {
+            challengeController.getChallenge(newUser1, 2L);
+        });
+    }
+
+    @Test
+    @DisplayName("챌린지 삭제 시, 정상적으로 없어지는지 테스트")
+    public void testIfDeleteChallengeIsNull() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
+            30L, 150000L, 10000L, 15L);
+
+        User newUser = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder()
+            .id(1L)
+            .category("이자율 받기")
+            .build();
+
+        TargetItem newTargetItem = TargetItem.builder()
+            .id(1L)
+            .name("전자제품")
+            .build();
+
+        Challenge newChallenge = Challenge.builder()
+            .title(challengeRequest.getTitle())
+            .isAchieved(false)
+            .totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice())
+            .weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory)
+            .targetItem(newTargetItem)
+            .status(1L)
+            .interestRate(challengeRequest.getInterestRate())
+            .build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder()
+            .challenge(newChallenge)
+            .member("parent")
+            .user(newUser)
+            .build();
+
+        Progress newProgress = Progress.builder()
+            .id(1L)
+            .weeks(1L)
+            .isAchieved(true)
+            .challenge(newChallenge)
+            .build();
+
+        Mockito.when(mockChallengeRepository.save(newChallenge))
+            .thenReturn(newChallenge);
+        Mockito.when(mockChallengeRepository.findById(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallenge));
+        Mockito.when(mockChallengeUserRepository.save(newChallengeUser))
+            .thenReturn(newChallengeUser);
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+
+        List<Progress> progressList = Arrays.asList(newProgress);
+        newChallenge.setProgressList(progressList);
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
+            mockChallengeRepository,
+            mockChallengeCategoryRepository,
+            mockTargetItemRepository,
+            mockChallengeUserRepository,
+            mockProgressRepository
+        );
+        ChallengeController challengeController = new ChallengeController(
+            challengeService
+        );
+        Long challengeId = newChallenge.getId();
+        CommonResponse result = challengeController.deleteChallenge(newUser, challengeId);
+
+        //then
+        ArgumentCaptor<ChallengeUser> cuCaptor = ArgumentCaptor.forClass(ChallengeUser.class);
+        ArgumentCaptor<Challenge> cCaptor = ArgumentCaptor.forClass(Challenge.class);
+
+        Mockito.verify(mockChallengeUserRepository, Mockito.times(1)).delete(cuCaptor.capture());
+        Mockito.verify(mockChallengeRepository, Mockito.times(1)).delete(cCaptor.capture());
+
+        Assertions.assertEquals(newChallenge, cCaptor.getValue());
+
+        Assertions.assertEquals(newChallengeUser, cuCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+    }
+
+    @Test
+    @DisplayName("챌린지 삭제 시, 챌린지를 생성한 유저가 아닌 경우 403 에러 테스트")
+    public void testIfNotAuthUserDeleteChallengeForbbiden() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
+            30L, 150000L, 10000L, 15L);
+
+        User newUser1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        User newUser2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder()
+            .id(1L)
+            .category("이자율 받기")
+            .build();
+
+        TargetItem newTargetItem = TargetItem.builder()
+            .id(1L)
+            .name("전자제품")
+            .build();
+
+        Challenge newChallenge = Challenge.builder()
+            .title(challengeRequest.getTitle())
+            .isAchieved(false)
+            .totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice())
+            .weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory)
+            .targetItem(newTargetItem)
+            .status(1L)
+            .interestRate(challengeRequest.getInterestRate())
+            .build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder()
+            .challenge(newChallenge)
+            .member("parent")
+            .user(newUser1)
+            .build();
+
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
+            mockChallengeRepository,
+            mockChallengeCategoryRepository,
+            mockTargetItemRepository,
+            mockChallengeUserRepository,
+            mockProgressRepository
+        );
+        ChallengeController challengeController = new ChallengeController(
+            challengeService
+        );
+        Long challengeId = newChallenge.getId();
+
+        //then
+        ChallengeDTO challengeDTO = new ChallengeDTO(newChallenge);
+
+        Assertions.assertThrows(ForbiddenException.class, () -> {
+            challengeController.deleteChallenge(newUser2, challengeId);
+        });
+    }
+
+    @Test
+    @DisplayName("생성한지 일주일이 넘은 돈길 삭제 시도 시, 400 에러 테스트")
+    public void testIfOverOneWeekChallengeTryDeleteBadRequest() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
+            30L, 150000L, 10000L, 15L);
+
+        User newUser1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder()
+            .id(1L)
+            .category("이자율 받기")
+            .build();
+
+        TargetItem newTargetItem = TargetItem.builder()
+            .id(1L)
+            .name("전자제품")
+            .build();
+
+        Challenge newChallenge = Challenge.builder()
+            .title(challengeRequest.getTitle())
+            .isAchieved(false)
+            .totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice())
+            .weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory)
+            .targetItem(newTargetItem)
+            .status(1L)
+            .interestRate(challengeRequest.getInterestRate())
+            .build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder()
+            .challenge(newChallenge)
+            .member("parent")
+            .user(newUser1)
+            .build();
+
+        Progress newProgress = Progress.builder()
+            .id(1L)
+            .weeks(1L)
+            .isAchieved(true)
+            .challenge(newChallenge)
+            .build();
+
+        Progress newProgress2 = Progress.builder()
+            .id(2L)
+            .weeks(2L)
+            .isAchieved(true)
+            .challenge(newChallenge)
+            .build();
+
+        List<Progress> progressList = Arrays.asList(newProgress, newProgress2);
+        newChallenge.setProgressList(progressList);
+        int size = newChallenge.getProgressList().size();
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
+            mockChallengeRepository,
+            mockChallengeCategoryRepository,
+            mockTargetItemRepository,
+            mockChallengeUserRepository,
+            mockProgressRepository
+        );
+        ChallengeController challengeController = new ChallengeController(
+            challengeService
+        );
+        Long challengeId = newChallenge.getId();
+
+        //then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            challengeController.deleteChallenge(newUser1, challengeId);
+        });
+    }
+
+    @Test
+    @DisplayName("챌린지 삭제 시, 챌린지 아이디로 챌린지를 못찾으면 404 에러 테스트")
+    public void testIfDeleteChallengeIsNullNotFoundErr() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기",
+            30L, 150000L, 10000L, 15L);
+
+        User newUser1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder()
+            .id(1L)
+            .category("이자율 받기")
+            .build();
+
+        TargetItem newTargetItem = TargetItem.builder()
+            .id(1L)
+            .name("전자제품")
+            .build();
+
+        Challenge newChallenge = Challenge.builder()
+            .title(challengeRequest.getTitle())
+            .isAchieved(false)
+            .totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice())
+            .weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory)
+            .targetItem(newTargetItem)
+            .status(1L)
+            .interestRate(challengeRequest.getInterestRate())
+            .build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder()
+            .challenge(newChallenge)
+            .member("parent")
+            .user(newUser1)
+            .build();
+
+        Progress newProgress = Progress.builder()
+            .id(1L)
+            .weeks(1L)
+            .isAchieved(true)
+            .challenge(newChallenge)
+            .build();
+
+        Progress newProgress2 = Progress.builder()
+            .id(2L)
+            .weeks(2L)
+            .isAchieved(true)
+            .challenge(newChallenge)
+            .build();
+
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(
+            mockChallengeRepository,
+            mockChallengeCategoryRepository,
+            mockTargetItemRepository,
+            mockChallengeUserRepository,
+            mockProgressRepository
+        );
+        ChallengeController challengeController = new ChallengeController(
+            challengeService
+        );
+        Long challengeId = newChallenge.getId();
+
+        //then
+        Assertions.assertThrows(NotFoundException.class, () -> {
+            challengeController.deleteChallenge(newUser1, 2L);
+        });
+    }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -365,4 +365,6 @@ public class ChallengeControllerTest {
         });
 
     }
+
+
 }


### PR DESCRIPTION
## 📝 PR Summary

* 챌린지 포기 API 작성 완료했습니다.
   * Validation(챌린지 조회 API와 공통 사항): PathVariable로 들어온 챌린지 아이디로 챌린지를 조회 (챌린지 못 찾으면 404) -> 챌린지-유저 미들테이블에 PathVariable로 들어온 챌린지 아이디와 jwt 토큰에서 추출한 유저와 매핑되어있는지 여부 검사 (없으면 403) -> 마지막으로 목표 아이템, 챌린지 카테고리, 주차수 검증 (null이거나 틀리면 400) -> (포기 API의 경우) 챌린지 생성한지 1주일 즉 Progress의 row들을 찾아보면서 해당 리스트의 사이즈가 2 이상이면은 400에러 발생

* 현재까지 작성한 챌린지 생성, 조회, 포기 API에 대해서 컨트롤러와 서비스 레이어 모두 Test 커버리지 100%로 완료했습니다.

![스크린샷 2022-07-07 오전 2 35 40](https://user-images.githubusercontent.com/59060780/177610097-9b796d55-8723-482c-8424-5627e93500a6.png)

![스크린샷 2022-07-07 오전 2 36 08](https://user-images.githubusercontent.com/59060780/177610176-8676ac42-10b3-406a-a6bc-7b98fb2835b0.png)



#### 🌲 Working Branch

* feature/deleteChallenge

### Related Issues

<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
