### PR TITLE
feat: 유저 관련 API 수정 및 리프레시 토큰

### DIFF
--- a/src/main/java/com/ceos/bankids/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/ceos/bankids/config/security/WebSecurityConfig.java
@@ -41,7 +41,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             .antMatchers("/health/**").permitAll()
             .antMatchers(SwaggerPatterns).permitAll()
             .antMatchers("/kakao/**").permitAll()
-//            .antMatchers("/auth/kakao/**").permitAll()
             .antMatchers("/user/refresh").permitAll()
             .anyRequest().authenticated()
             .and()

--- a/src/main/java/com/ceos/bankids/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/ceos/bankids/config/security/WebSecurityConfig.java
@@ -59,6 +59,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     private CorsConfiguration getDefaultCorsConfiguration() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.addAllowedOrigin("https://bankids.click");
+        configuration.addAllowedOrigin("https://bankidz.com");
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
 

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -3,6 +3,7 @@ package com.ceos.bankids.controller;
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
@@ -41,11 +42,12 @@ public class UserController {
     @ApiOperation(value = "토큰 리프레시")
     @GetMapping(value = "/refresh", produces = "application/json; charset=utf-8")
     @ResponseBody
-    public CommonResponse<String> refreshUserToken(@AuthenticationPrincipal User authUser,
+    public CommonResponse<LoginDTO> refreshUserToken(@AuthenticationPrincipal User authUser,
         @CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
 
-        String accessToken = userService.issueNewTokens(authUser, refreshToken, response);
+        LoginDTO loginDTO = userService.issueNewTokens(authUser, refreshToken, true, response);
 
-        return CommonResponse.onSuccess(accessToken);
+        return CommonResponse.onSuccess(loginDTO);
     }
+
 }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -6,11 +6,14 @@ import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,6 +34,18 @@ public class UserController {
         @Valid @RequestBody UserTypeRequest userTypeRequest) {
 
         UserDTO userDTO = userService.updateUserType(authUser, userTypeRequest);
+
         return CommonResponse.onSuccess(userDTO);
+    }
+
+    @ApiOperation(value = "토큰 리프레시")
+    @GetMapping(value = "/refresh", produces = "application/json; charset=utf-8")
+    @ResponseBody
+    public CommonResponse<String> refreshUserToken(@AuthenticationPrincipal User authUser,
+        @CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
+
+        String accessToken = userService.issueNewTokens(authUser, refreshToken, response);
+
+        return CommonResponse.onSuccess(accessToken);
     }
 }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
     public CommonResponse<LoginDTO> refreshUserToken(@AuthenticationPrincipal User authUser,
         @CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
 
-        LoginDTO loginDTO = userService.issueNewTokens(authUser, refreshToken, true, response);
+        LoginDTO loginDTO = userService.issueNewTokens(authUser, true, response);
 
         return CommonResponse.onSuccess(loginDTO);
     }

--- a/src/main/java/com/ceos/bankids/controller/request/UserTypeRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/UserTypeRequest.java
@@ -15,6 +15,10 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UserTypeRequest {
 
+    @ApiModelProperty(example = "19990521")
+    @NotNull(message = "birthday may not be null")
+    private String birthday;
+
     @ApiModelProperty(example = "false")
     @NotNull(message = "isFemale may not be null")
     private Boolean isFemale;

--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -17,6 +17,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
@@ -27,6 +28,7 @@ import org.hibernate.annotations.DynamicInsert;
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
 @DynamicInsert
+@ToString(exclude = {"progressList", "challengeUserList"})
 public class Challenge extends AbstractTimestamp {
 
     @Id

--- a/src/main/java/com/ceos/bankids/domain/ChallengeCategory.java
+++ b/src/main/java/com/ceos/bankids/domain/ChallengeCategory.java
@@ -14,6 +14,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Getter
@@ -21,6 +22,7 @@ import lombok.Setter;
 @Table(name = "ChallengeCategory")
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
+@ToString(exclude = "challengeList")
 public class ChallengeCategory extends AbstractTimestamp {
 
     @Id

--- a/src/main/java/com/ceos/bankids/domain/Family.java
+++ b/src/main/java/com/ceos/bankids/domain/Family.java
@@ -14,6 +14,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
@@ -21,6 +22,7 @@ import lombok.Setter;
 @Table(name = "Family")
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
+@ToString(exclude = "familyUserList")
 public class Family {
 
     @Id

--- a/src/main/java/com/ceos/bankids/domain/Kid.java
+++ b/src/main/java/com/ceos/bankids/domain/Kid.java
@@ -44,6 +44,7 @@ public class Kid extends AbstractTimestamp {
     public Kid(
         Long id,
         Long savings,
+        Long level,
         User user
     ) {
         if (savings == null) {
@@ -54,6 +55,7 @@ public class Kid extends AbstractTimestamp {
         }
         this.id = id;
         this.savings = savings;
+        this.level = level;
         this.user = user;
     }
 }

--- a/src/main/java/com/ceos/bankids/domain/Parent.java
+++ b/src/main/java/com/ceos/bankids/domain/Parent.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -13,6 +14,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Setter
@@ -26,6 +28,10 @@ public class Parent extends AbstractTimestamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 10)
+    @ColumnDefault("0")
+    private Long savings;
+
     @OneToOne
     @JoinColumn(name = "userId", nullable = false)
     private User user;
@@ -33,12 +39,14 @@ public class Parent extends AbstractTimestamp {
     @Builder
     public Parent(
         Long id,
+        Long savings,
         User user
     ) {
         if (user == null) {
             throw new BadRequestException("유저는 필수값입니다.");
         }
         this.id = id;
+        this.savings = savings;
         this.user = user;
     }
 }

--- a/src/main/java/com/ceos/bankids/domain/TargetItem.java
+++ b/src/main/java/com/ceos/bankids/domain/TargetItem.java
@@ -14,6 +14,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Getter
@@ -21,6 +22,7 @@ import lombok.Setter;
 @Table(name = "TargetItem")
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
+@ToString(exclude = "challengeList")
 public class TargetItem extends AbstractTimestamp {
 
     @Id

--- a/src/main/java/com/ceos/bankids/domain/User.java
+++ b/src/main/java/com/ceos/bankids/domain/User.java
@@ -28,7 +28,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 @Table(name = "User")
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
-@ToString(exclude = {"kids", "parents"})
+@ToString(exclude = {"challengeUserList", "challengeUserList"})
 public class User extends AbstractTimestamp implements UserDetails {
 
     @Id

--- a/src/main/java/com/ceos/bankids/domain/User.java
+++ b/src/main/java/com/ceos/bankids/domain/User.java
@@ -105,8 +105,6 @@ public class User extends AbstractTimestamp implements UserDetails {
         this.provider = provider;
         this.isKid = isKid;
         this.refreshToken = refreshToken;
-        this.parent = parent;
-        this.kid = kid;
     }
 
     @Override

--- a/src/main/java/com/ceos/bankids/service/JwtTokenServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/JwtTokenServiceImpl.java
@@ -35,7 +35,8 @@ public class JwtTokenServiceImpl implements JwtTokenService {
             .setIssuer("bankids")
             .setIssuedAt(now)
             .setSubject(tokenDTO.getId().toString())
-            .setExpiration(new Date(now.getTime() + Duration.ofMinutes(2880).toMillis()))
+//            .setExpiration(new Date(now.getTime() + Duration.ofMinutes(2880).toMillis()))
+            .setExpiration(new Date(now.getTime() + Duration.ofMinutes(40320).toMillis()))
             .claim("id", tokenDTO.getId())
             .claim("roles", "USER")
             .signWith(SignatureAlgorithm.HS256,

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -69,9 +69,8 @@ public class KakaoServiceImpl implements KakaoService {
         HttpServletResponse response) {
         Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
         if (user.isPresent()) {
-            String accessToken = userService.issueNewTokens(user.get(), null, response);
+            LoginDTO loginDTO = userService.issueNewTokens(user.get(), null, true, response);
 
-            LoginDTO loginDTO = new LoginDTO(true, user.get().getIsKid(), accessToken);
             return loginDTO;
         } else {
             User newUser = User.builder()
@@ -81,9 +80,8 @@ public class KakaoServiceImpl implements KakaoService {
                 .build();
             uRepo.save(newUser);
 
-            String accessToken = userService.issueNewTokens(newUser, null, response);
+            LoginDTO loginDTO = userService.issueNewTokens(newUser, null, false, response);
 
-            LoginDTO loginDTO = new LoginDTO(false, null, accessToken);
             return loginDTO;
         }
     }

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -3,13 +3,11 @@ package com.ceos.bankids.service;
 import com.ceos.bankids.controller.request.KakaoRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.LoginDTO;
-import com.ceos.bankids.dto.TokenDTO;
 import com.ceos.bankids.dto.oauth.KakaoTokenDTO;
 import com.ceos.bankids.dto.oauth.KakaoUserDTO;
 import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.repository.UserRepository;
 import java.util.Optional;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,8 +24,8 @@ import reactor.core.publisher.Mono;
 public class KakaoServiceImpl implements KakaoService {
 
     private final UserRepository uRepo;
-    private final JwtTokenServiceImpl jwtTokenServiceImpl;
     private final WebClient webClient;
+    private final UserServiceImpl userService;
 
     @Value("${kakao.key}")
     private String KAKAO_KEY;
@@ -71,23 +69,9 @@ public class KakaoServiceImpl implements KakaoService {
         HttpServletResponse response) {
         Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
         if (user.isPresent()) {
-            TokenDTO tokenDTO = new TokenDTO(user.get());
+            String accessToken = userService.issueNewTokens(user.get(), null, response);
 
-            String refreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(user.get().getId());
-            user.get().setRefreshToken(refreshToken);
-            uRepo.save(user.get());
-
-            Cookie cookie = new Cookie("refreshToken", user.get().getRefreshToken());
-
-            cookie.setMaxAge(14 * 24 * 60 * 60);
-            cookie.setSecure(true);
-            cookie.setHttpOnly(true);
-            cookie.setPath("/");
-
-            response.addCookie(cookie);
-
-            LoginDTO loginDTO = new LoginDTO(true, user.get().getIsKid(),
-                jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
+            LoginDTO loginDTO = new LoginDTO(true, user.get().getIsKid(), accessToken);
             return loginDTO;
         } else {
             User newUser = User.builder()
@@ -97,22 +81,9 @@ public class KakaoServiceImpl implements KakaoService {
                 .build();
             uRepo.save(newUser);
 
-            String refreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(newUser.getId());
-            newUser.setRefreshToken(refreshToken);
-            uRepo.save(newUser);
+            String accessToken = userService.issueNewTokens(newUser, null, response);
 
-            Cookie cookie = new Cookie("refreshToken", refreshToken);
-
-            cookie.setMaxAge(14 * 24 * 60 * 60);
-            cookie.setSecure(true);
-            cookie.setHttpOnly(true);
-            cookie.setPath("/");
-
-            response.addCookie(cookie);
-
-            TokenDTO tokenDTO = new TokenDTO(newUser);
-            LoginDTO loginDTO = new LoginDTO(false, null,
-                jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
+            LoginDTO loginDTO = new LoginDTO(false, null, accessToken);
             return loginDTO;
         }
     }

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -72,6 +72,11 @@ public class KakaoServiceImpl implements KakaoService {
         Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
         if (user.isPresent()) {
             TokenDTO tokenDTO = new TokenDTO(user.get());
+
+            String refreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(user.get().getId());
+            user.get().setRefreshToken(refreshToken);
+            uRepo.save(user.get());
+
             Cookie cookie = new Cookie("refreshToken", user.get().getRefreshToken());
 
             cookie.setMaxAge(14 * 24 * 60 * 60);

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -69,7 +69,7 @@ public class KakaoServiceImpl implements KakaoService {
         HttpServletResponse response) {
         Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
         if (user.isPresent()) {
-            LoginDTO loginDTO = userService.issueNewTokens(user.get(), null, true, response);
+            LoginDTO loginDTO = userService.issueNewTokens(user.get(), true, response);
 
             return loginDTO;
         } else {
@@ -80,7 +80,7 @@ public class KakaoServiceImpl implements KakaoService {
                 .build();
             uRepo.save(newUser);
 
-            LoginDTO loginDTO = userService.issueNewTokens(newUser, null, false, response);
+            LoginDTO loginDTO = userService.issueNewTokens(newUser, false, response);
 
             return loginDTO;
         }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -2,6 +2,7 @@ package com.ceos.bankids.service;
 
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.UserDTO;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -15,6 +16,6 @@ public interface UserService {
     public UserDTO updateUserType(@AuthenticationPrincipal User authUser,
         @Valid @RequestBody UserTypeRequest userTypeRequest);
 
-    public String issueNewTokens(@AuthenticationPrincipal User authUser,
-        String refreshToken, HttpServletResponse response);
+    public LoginDTO issueNewTokens(@AuthenticationPrincipal User authUser,
+        String refreshToken, Boolean isRegistered, HttpServletResponse response);
 }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -3,6 +3,7 @@ package com.ceos.bankids.service;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.UserDTO;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
@@ -13,4 +14,7 @@ public interface UserService {
 
     public UserDTO updateUserType(@AuthenticationPrincipal User authUser,
         @Valid @RequestBody UserTypeRequest userTypeRequest);
+
+    public String issueNewTokens(@AuthenticationPrincipal User authUser,
+        String refreshToken, HttpServletResponse response);
 }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -16,6 +16,6 @@ public interface UserService {
     public UserDTO updateUserType(@AuthenticationPrincipal User authUser,
         @Valid @RequestBody UserTypeRequest userTypeRequest);
 
-    public LoginDTO issueNewTokens(@AuthenticationPrincipal User authUser,
-        String refreshToken, Boolean isRegistered, HttpServletResponse response);
+    public LoginDTO issueNewTokens(@AuthenticationPrincipal User authUser, Boolean isRegistered,
+        HttpServletResponse response);
 }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.Kid;
 import com.ceos.bankids.domain.Parent;
 import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.TokenDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.exception.BadRequestException;
@@ -66,13 +67,13 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public String issueNewTokens(User user, String prevRefreshToken,
+    public LoginDTO issueNewTokens(User user, String prevRefreshToken, Boolean isRegistered,
         HttpServletResponse response) {
-        TokenDTO tokenDTO = new TokenDTO(user);
-
         String newRefreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(user.getId());
         user.setRefreshToken(newRefreshToken);
         uRepo.save(user);
+
+        TokenDTO tokenDTO = new TokenDTO(user);
 
         Cookie cookie = new Cookie("refreshToken", user.getRefreshToken());
 
@@ -83,6 +84,8 @@ public class UserServiceImpl implements UserService {
 
         response.addCookie(cookie);
 
-        return jwtTokenServiceImpl.encodeJwtToken(tokenDTO);
+        LoginDTO loginDTO = new LoginDTO(isRegistered, user.getIsKid(),
+            jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
+        return loginDTO;
     }
 }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -43,10 +43,10 @@ public class UserServiceImpl implements UserService {
                 Kid newKid = Kid.builder()
                     .savings(0L)
                     .user(user.get())
+                    .level(1L)
                     .build();
                 kRepo.save(newKid);
             } else {
-                System.out.println("PARENT!!!");
                 Parent newParent = Parent.builder()
                     .user(user.get())
                     .build();

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -34,6 +34,7 @@ public class UserServiceImpl implements UserService {
         if (user.isEmpty()) {
             throw new BadRequestException("존재하지 않는 유저입니다.");
         } else {
+            user.get().setBirthday(userTypeRequest.getBirthday());
             user.get().setIsFemale(userTypeRequest.getIsFemale());
             user.get().setIsKid(userTypeRequest.getIsKid());
             uRepo.save(user.get());
@@ -45,6 +46,7 @@ public class UserServiceImpl implements UserService {
                     .build();
                 kRepo.save(newKid);
             } else {
+                System.out.println("PARENT!!!");
                 Parent newParent = Parent.builder()
                     .user(user.get())
                     .build();

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -53,7 +53,7 @@ public class UserServiceImpl implements UserService {
                     .level(1L)
                     .build();
                 kRepo.save(newKid);
-            } else if (user.get().getIsKid() == false) {
+            } else {
                 Parent newParent = Parent.builder()
                     .savings(0L)
                     .user(user.get())
@@ -67,7 +67,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public LoginDTO issueNewTokens(User user, String prevRefreshToken, Boolean isRegistered,
+    public LoginDTO issueNewTokens(User user, Boolean isRegistered,
         HttpServletResponse response) {
         String newRefreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(user.getId());
         user.setRefreshToken(newRefreshToken);

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -33,21 +33,24 @@ public class UserServiceImpl implements UserService {
         Optional<User> user = uRepo.findById(userId);
         if (user.isEmpty()) {
             throw new BadRequestException("존재하지 않는 유저입니다.");
+        } else if (user.get().getIsFemale() != null) {
+            throw new BadRequestException("이미 유저 타입을 선택한 유저입니다.");
         } else {
             user.get().setBirthday(userTypeRequest.getBirthday());
             user.get().setIsFemale(userTypeRequest.getIsFemale());
             user.get().setIsKid(userTypeRequest.getIsKid());
             uRepo.save(user.get());
 
-            if (user.get().getIsKid()) {
+            if (user.get().getIsKid() == true) {
                 Kid newKid = Kid.builder()
                     .savings(0L)
                     .user(user.get())
                     .level(1L)
                     .build();
                 kRepo.save(newKid);
-            } else {
+            } else if (user.get().getIsKid() == false) {
                 Parent newParent = Parent.builder()
+                    .savings(0L)
                     .user(user.get())
                     .build();
                 pRepo.save(newParent);

--- a/src/test/java/com/ceos/bankids/unit/controller/KakaoControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/KakaoControllerTest.java
@@ -3,8 +3,8 @@ package com.ceos.bankids.unit.controller;
 import com.ceos.bankids.controller.KakaoController;
 import com.ceos.bankids.controller.request.KakaoRequest;
 import com.ceos.bankids.repository.UserRepository;
-import com.ceos.bankids.service.JwtTokenServiceImpl;
 import com.ceos.bankids.service.KakaoServiceImpl;
+import com.ceos.bankids.service.UserServiceImpl;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -21,13 +21,13 @@ public class KakaoControllerTest {
         HttpServletResponse response = null;
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         WebClient mockWebClient = Mockito.mock(WebClient.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
 
         // when
         KakaoServiceImpl kakaoService = new KakaoServiceImpl(
             mockUserRepository,
-            jwtTokenServiceImpl,
-            mockWebClient
+            mockWebClient,
+            mockUserService
         );
         KakaoController kakaoController = new KakaoController(
             kakaoService
@@ -46,14 +46,14 @@ public class KakaoControllerTest {
         HttpServletResponse response = null;
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         WebClient mockWebClient = Mockito.mock(WebClient.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
         KakaoRequest kakaoRequest = new KakaoRequest("code");
 
         // when
         KakaoServiceImpl kakaoService = new KakaoServiceImpl(
             mockUserRepository,
-            jwtTokenServiceImpl,
-            mockWebClient
+            mockWebClient,
+            mockUserService
         );
         KakaoController kakaoController = new KakaoController(
             kakaoService

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.Kid;
 import com.ceos.bankids.domain.Parent;
 import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.TokenDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.exception.BadRequestException;
@@ -323,6 +324,7 @@ public class UserControllerTest {
         CommonResponse result = userController.refreshUserToken(user, "rT", response);
 
         // then
-        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+        LoginDTO loginDTO = new LoginDTO(true, false, "aT");
+        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.repository.KidRepository;
 import com.ceos.bankids.repository.ParentRepository;
 import com.ceos.bankids.repository.UserRepository;
+import com.ceos.bankids.service.JwtTokenServiceImpl;
 import com.ceos.bankids.service.UserServiceImpl;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
@@ -38,12 +39,14 @@ public class UserControllerTest {
             .thenReturn(Optional.ofNullable(user));
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
-            mockParentRepository
+            mockParentRepository,
+            jwtTokenServiceImpl
         );
         UserController userController = new UserController(
             userService
@@ -75,12 +78,14 @@ public class UserControllerTest {
             .thenReturn(Optional.ofNullable(user));
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
-            mockParentRepository
+            mockParentRepository,
+            jwtTokenServiceImpl
         );
         UserController userController = new UserController(
             userService
@@ -109,12 +114,14 @@ public class UserControllerTest {
             .thenReturn(Optional.ofNullable(null));
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
-            mockParentRepository
+            mockParentRepository,
+            jwtTokenServiceImpl
         );
         UserController userController = new UserController(
             userService
@@ -150,12 +157,14 @@ public class UserControllerTest {
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         Mockito.when(mockKidRepository.save(kid)).thenReturn(kid);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
-            mockParentRepository
+            mockParentRepository,
+            jwtTokenServiceImpl
         );
         UserController userController = new UserController(
             userService
@@ -202,12 +211,14 @@ public class UserControllerTest {
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
         Mockito.when(mockParentRepository.save(parent)).thenReturn(parent);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
-            mockParentRepository
+            mockParentRepository,
+            jwtTokenServiceImpl
         );
         UserController userController = new UserController(
             userService
@@ -250,12 +261,14 @@ public class UserControllerTest {
             .thenReturn(Optional.ofNullable(null));
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
             mockKidRepository,
-            mockParentRepository
+            mockParentRepository,
+            jwtTokenServiceImpl
         );
         UserController userController = new UserController(
             userService

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -28,14 +28,11 @@ public class UserControllerTest {
         User user = User.builder()
             .id(1L)
             .username("user1")
-            .isFemale(true)
-            .birthday("19990521")
             .authenticationCode("code")
             .provider("kakao")
-            .isKid(true)
             .refreshToken("token")
             .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest(false, false);
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         Mockito.when(mockUserRepository.findById(1L))
             .thenReturn(Optional.ofNullable(user));
@@ -54,8 +51,9 @@ public class UserControllerTest {
         CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
 
         // then
-        user.setIsKid(false);
+        user.setBirthday("19990521");
         user.setIsFemale(false);
+        user.setIsKid(true);
         UserDTO userDTO = new UserDTO(user);
         Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
     }
@@ -67,14 +65,11 @@ public class UserControllerTest {
         User user = User.builder()
             .id(1L)
             .username("user1")
-            .isFemale(true)
-            .birthday("19990521")
             .authenticationCode("code")
             .provider("kakao")
-            .isKid(true)
             .refreshToken("token")
             .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest(false, false);
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         Mockito.when(mockUserRepository.findById(1L))
             .thenReturn(Optional.ofNullable(user));
@@ -104,14 +99,11 @@ public class UserControllerTest {
         User user = User.builder()
             .id(1L)
             .username("user1")
-            .isFemale(true)
-            .birthday("19990521")
             .authenticationCode("code")
             .provider("kakao")
-            .isKid(true)
             .refreshToken("token")
             .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest(false, false);
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         Mockito.when(mockUserRepository.findById(1L))
             .thenReturn(Optional.ofNullable(null));
@@ -141,18 +133,15 @@ public class UserControllerTest {
         User user = User.builder()
             .id(1L)
             .username("user1")
-            .isFemale(true)
-            .birthday("19990521")
             .authenticationCode("code")
             .provider("kakao")
-            .isKid(true)
             .refreshToken("token")
             .build();
         Kid kid = Kid.builder()
             .savings(0L)
             .user(user)
             .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest(false, true);
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         Mockito.when(mockUserRepository.findById(1L))
             .thenReturn(Optional.ofNullable(user));
@@ -173,6 +162,7 @@ public class UserControllerTest {
         CommonResponse result = userController.patchUserType(user, userTypeRequest);
 
         // then
+        user.setBirthday("19990521");
         user.setIsFemale(false);
         user.setIsKid(true);
         UserDTO userDTO = new UserDTO(user);
@@ -195,17 +185,14 @@ public class UserControllerTest {
         User user = User.builder()
             .id(1L)
             .username("user1")
-            .isFemale(true)
-            .birthday("19990521")
             .authenticationCode("code")
             .provider("kakao")
-            .isKid(true)
             .refreshToken("token")
             .build();
         Parent parent = Parent.builder()
             .user(user)
             .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest(true, false);
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         Mockito.when(mockUserRepository.findById(1L))
             .thenReturn(Optional.ofNullable(user));
@@ -226,8 +213,9 @@ public class UserControllerTest {
         CommonResponse result = userController.patchUserType(user, userTypeRequest);
 
         // then
-        user.setIsFemale(true);
-        user.setIsKid(false);
+        user.setBirthday("19990521");
+        user.setIsFemale(false);
+        user.setIsKid(true);
         UserDTO userDTO = new UserDTO(user);
 
         ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -65,6 +65,44 @@ public class UserControllerTest {
     }
 
     @Test
+    @DisplayName("유저 정보 이미 있어 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWhenAlreadyPatchedThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        UserController userController = new UserController(
+            userService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
     @DisplayName("body 없어서 패치 실패시, 에러 처리 되는지 확인")
     public void testIfUserTypePatchFailWithoutArgumentsThrowNullPointerException() {
         // given


### PR DESCRIPTION
## 📝 PR Summary
- 기획 변동에 따른 유저로부터 온보딩 과정 중 생년월일 입력 받기 추가
- kid, parent row 중복 생성 방지
- refresh token api 작성
- controller + service 계층 테스트 코드 작성, 커버리지 100%
- aT 기간 개발 편의를 위해 늘리고, config에 dev와 prod 도메인 주소 추가
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/userToken
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] birthday 입력 추가
- [x] kid, parent 중복 생성
- [x] refresh token
- [x] 개발 편의 위한 config 변경
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#16
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
