### PR TITLE
feat: 가족 생성하기

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/FamilyController.java
+++ b/src/main/java/com/ceos/bankids/controller/FamilyController.java
@@ -1,0 +1,31 @@
+package com.ceos.bankids.controller;
+
+import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.FamilyDTO;
+import com.ceos.bankids.service.FamilyServiceImpl;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Log
+@Controller
+@RequestMapping("/family")
+@RequiredArgsConstructor
+public class FamilyController {
+
+    private final FamilyServiceImpl familyService;
+
+    @PostMapping(value = "", produces = "application/json; charset=utf-8")
+    @ResponseBody
+    public CommonResponse<FamilyDTO> postNewFamily(@AuthenticationPrincipal User authUser) {
+
+        FamilyDTO familyDTO = familyService.postNewFamily(authUser);
+
+        return CommonResponse.onSuccess(familyDTO);
+    }
+}

--- a/src/main/java/com/ceos/bankids/dto/FamilyDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/FamilyDTO.java
@@ -1,0 +1,24 @@
+package com.ceos.bankids.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class FamilyDTO {
+
+    @ApiModelProperty(example = "asdfas")
+    private String code;
+    @ApiModelProperty(example = "true")
+    private List<FamilyUserDTO> familyUserList;
+
+
+    public FamilyDTO(String code, List<FamilyUserDTO> familyUserList) {
+        this.code = code;
+        this.familyUserList = familyUserList;
+    }
+}

--- a/src/main/java/com/ceos/bankids/dto/FamilyDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/FamilyDTO.java
@@ -1,24 +1,31 @@
 package com.ceos.bankids.dto;
 
+import com.ceos.bankids.domain.Family;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
+@Setter
 @ToString
 @EqualsAndHashCode
 public class FamilyDTO {
 
+    @ApiModelProperty(example = "1")
+    private Long id;
     @ApiModelProperty(example = "asdfas")
     private String code;
     @ApiModelProperty(example = "true")
     private List<FamilyUserDTO> familyUserList;
 
 
-    public FamilyDTO(String code, List<FamilyUserDTO> familyUserList) {
-        this.code = code;
+    public FamilyDTO(Family family, List<FamilyUserDTO> familyUserList) {
+        this.id = family.getId();
+        this.code = family.getCode();
         this.familyUserList = familyUserList;
     }
+
 }

--- a/src/main/java/com/ceos/bankids/dto/FamilyUserDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/FamilyUserDTO.java
@@ -1,0 +1,27 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.User;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class FamilyUserDTO {
+
+    @ApiModelProperty(example = "주어랑")
+    String username;
+    @ApiModelProperty(example = "true")
+    Boolean isFemale;
+    @ApiModelProperty(example = "true")
+    Boolean isKid;
+
+
+    public FamilyUserDTO(User user) {
+        this.username = user.getUsername();
+        this.isFemale = user.getIsFemale();
+        this.isKid = user.getIsKid();
+    }
+}

--- a/src/main/java/com/ceos/bankids/repository/FamilyRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/FamilyRepository.java
@@ -1,0 +1,8 @@
+package com.ceos.bankids.repository;
+
+import com.ceos.bankids.domain.Family;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FamilyRepository extends JpaRepository<Family, Long> {
+
+}

--- a/src/main/java/com/ceos/bankids/repository/FamilyRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/FamilyRepository.java
@@ -1,8 +1,10 @@
 package com.ceos.bankids.repository;
 
 import com.ceos.bankids.domain.Family;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FamilyRepository extends JpaRepository<Family, Long> {
 
+    public Optional<Family> findById(Long id);
 }

--- a/src/main/java/com/ceos/bankids/repository/FamilyUserRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/FamilyUserRepository.java
@@ -1,0 +1,14 @@
+package com.ceos.bankids.repository;
+
+import com.ceos.bankids.domain.FamilyUser;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FamilyUserRepository extends JpaRepository<FamilyUser, Long> {
+
+    public Optional<FamilyUser> findByUserId(Long id);
+
+    public List<FamilyUser> findByFamilyId(Long id);
+
+}

--- a/src/main/java/com/ceos/bankids/repository/FamilyUserRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/FamilyUserRepository.java
@@ -1,5 +1,6 @@
 package com.ceos.bankids.repository;
 
+import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.FamilyUser;
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +10,6 @@ public interface FamilyUserRepository extends JpaRepository<FamilyUser, Long> {
 
     public Optional<FamilyUser> findByUserId(Long id);
 
-    public List<FamilyUser> findByFamilyId(Long id);
+    public List<FamilyUser> findByFamily(Family family);
 
 }

--- a/src/main/java/com/ceos/bankids/service/FamilyService.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyService.java
@@ -1,5 +1,6 @@
 package com.ceos.bankids.service;
 
+import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.FamilyUserDTO;
@@ -11,6 +12,6 @@ public interface FamilyService {
 
     public FamilyDTO postNewFamily(User user);
 
-    public List<FamilyUserDTO> getFamilyUserList(Long familyId);
+    public List<FamilyUserDTO> getFamilyUserList(Family family);
 
 }

--- a/src/main/java/com/ceos/bankids/service/FamilyService.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyService.java
@@ -1,0 +1,16 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.FamilyDTO;
+import com.ceos.bankids.dto.FamilyUserDTO;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface FamilyService {
+
+    public FamilyDTO postNewFamily(User user);
+
+    public List<FamilyUserDTO> getFamilyUserList(Long familyId);
+
+}

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -1,12 +1,15 @@
 package com.ceos.bankids.service;
 
+import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.FamilyUser;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.FamilyUserDTO;
+import com.ceos.bankids.repository.FamilyRepository;
 import com.ceos.bankids.repository.FamilyUserRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FamilyServiceImpl implements FamilyService {
 
+    private final FamilyRepository fRepo;
     private final FamilyUserRepository fuRepo;
 
     @Override
@@ -31,10 +35,23 @@ public class FamilyServiceImpl implements FamilyService {
 
             return familyDTO;
         } else {
+            String newFamilyCode = UUID.randomUUID().toString();
+            Family newFamily = Family.builder()
+                .code(newFamilyCode)
+                .build();
+            fRepo.save(newFamily);
 
+            FamilyUser newFamilyUser = FamilyUser.builder()
+                .user(user)
+                .family(newFamily)
+                .build();
+            fuRepo.save(newFamilyUser);
+
+            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(newFamily.getId());
+            FamilyDTO familyDTO = new FamilyDTO(newFamilyCode, familyUserDTOList);
+
+            return familyDTO;
         }
-
-        return null;
     }
 
     @Override

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -28,10 +28,9 @@ public class FamilyServiceImpl implements FamilyService {
         Optional<FamilyUser> familyUser = fuRepo.findByUserId(user.getId());
 
         if (familyUser.isPresent()) {
-            String code = familyUser.get().getFamily().getCode();
             List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(
-                familyUser.get().getFamily().getId());
-            FamilyDTO familyDTO = new FamilyDTO(code, familyUserDTOList);
+                familyUser.get().getFamily());
+            FamilyDTO familyDTO = new FamilyDTO(familyUser.get().getFamily(), familyUserDTOList);
 
             return familyDTO;
         } else {
@@ -47,8 +46,8 @@ public class FamilyServiceImpl implements FamilyService {
                 .build();
             fuRepo.save(newFamilyUser);
 
-            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(newFamily.getId());
-            FamilyDTO familyDTO = new FamilyDTO(newFamilyCode, familyUserDTOList);
+            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(newFamily);
+            FamilyDTO familyDTO = new FamilyDTO(newFamily, familyUserDTOList);
 
             return familyDTO;
         }
@@ -56,8 +55,8 @@ public class FamilyServiceImpl implements FamilyService {
 
     @Override
     @Transactional
-    public List<FamilyUserDTO> getFamilyUserList(Long familyId) {
-        List<FamilyUser> familyUser = fuRepo.findByFamilyId(familyId);
+    public List<FamilyUserDTO> getFamilyUserList(Family family) {
+        List<FamilyUser> familyUser = fuRepo.findByFamily(family);
 
         List<FamilyUserDTO> userDTOList = familyUser.stream().map(FamilyUser::getUser)
             .map(FamilyUserDTO::new)

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -1,0 +1,51 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.FamilyUser;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.FamilyDTO;
+import com.ceos.bankids.dto.FamilyUserDTO;
+import com.ceos.bankids.repository.FamilyUserRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FamilyServiceImpl implements FamilyService {
+
+    private final FamilyUserRepository fuRepo;
+
+    @Override
+    @Transactional
+    public FamilyDTO postNewFamily(User user) {
+        Optional<FamilyUser> familyUser = fuRepo.findByUserId(user.getId());
+
+        if (familyUser.isPresent()) {
+            String code = familyUser.get().getFamily().getCode();
+            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(
+                familyUser.get().getFamily().getId());
+            FamilyDTO familyDTO = new FamilyDTO(code, familyUserDTOList);
+
+            return familyDTO;
+        } else {
+
+        }
+
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public List<FamilyUserDTO> getFamilyUserList(Long familyId) {
+        List<FamilyUser> familyUser = fuRepo.findByFamilyId(familyId);
+
+        List<FamilyUserDTO> userDTOList = familyUser.stream().map(FamilyUser::getUser)
+            .map(FamilyUserDTO::new)
+            .collect(Collectors.toList());
+
+        return userDTOList;
+    }
+}

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -5,6 +5,7 @@ import com.ceos.bankids.domain.FamilyUser;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.FamilyUserDTO;
+import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.repository.FamilyRepository;
 import com.ceos.bankids.repository.FamilyUserRepository;
 import java.util.List;
@@ -28,6 +29,10 @@ public class FamilyServiceImpl implements FamilyService {
         Optional<FamilyUser> familyUser = fuRepo.findByUserId(user.getId());
 
         if (familyUser.isPresent()) {
+            Optional<Family> family = fRepo.findById(familyUser.get().getFamily().getId());
+            if (family.isEmpty()) {
+                throw new BadRequestException("삭제된 가족입니다.");
+            }
             List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(
                 familyUser.get().getFamily());
             FamilyDTO familyDTO = new FamilyDTO(familyUser.get().getFamily(), familyUserDTOList);

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -1,0 +1,129 @@
+package com.ceos.bankids.unit.controller;
+
+import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.FamilyController;
+import com.ceos.bankids.domain.Family;
+import com.ceos.bankids.domain.FamilyUser;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.FamilyDTO;
+import com.ceos.bankids.dto.FamilyUserDTO;
+import com.ceos.bankids.repository.FamilyRepository;
+import com.ceos.bankids.repository.FamilyUserRepository;
+import com.ceos.bankids.service.FamilyServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class FamilyControllerTest {
+
+    @Test
+    @DisplayName("기존 가족 있을 때, 가족 정보 반환하는지 확인")
+    public void testIfFamilyExistThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+        CommonResponse<FamilyDTO> result = familyController.postNewFamily(user1);
+
+        // then
+        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
+            .map(FamilyUserDTO::new).collect(Collectors.toList());
+        FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("기존 가족 없을 때, 가족 생성 후 정보 반환하는지 확인")
+    public void testIfFamilyNotExistThenPostAndReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+
+        Family family = Family.builder().code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser1);
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+        CommonResponse<FamilyDTO> result = familyController.postNewFamily(user1);
+        String code = result.getData().getCode();
+        family.setCode(code);
+
+        // then
+        ArgumentCaptor<Family> fCaptor = ArgumentCaptor.forClass(Family.class);
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        Mockito.verify(mockFamilyRepository, Mockito.times(1)).save(fCaptor.capture());
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
+
+        Assertions.assertEquals(family, fCaptor.getValue());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
+            .map(FamilyUserDTO::new).collect(Collectors.toList());
+        FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
+
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+}


### PR DESCRIPTION
## 📝 PR Summary
- 기존 가족이 있는지 확인하고 없다면 가족 생성하여 정보 반환
- 가족 구성원 리스트를 가져올 때, 탈퇴한 유저 검사 x
- 이 후, 유저 탈퇴 시 유저의 데이터 함께 지워줘야 함
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/newFamily
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] 기존 가족이 있는지 여부 확인
- [x] 있다면 가족 정보 반환
- [x] 없다면 가족 생성 후 가족 정보 반환
- [x] 에러 처리
- [x] 테스트 코드

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#24
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
