### PR TITLE
feat: 돈길 걷기(이번주 저금하기) API 작성 및 돈길 관련 API 응답에 progress 정보 추가

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/ChallengeController.java
+++ b/src/main/java/com/ceos/bankids/controller/ChallengeController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -60,9 +61,9 @@ public class ChallengeController {
     @ApiOperation(value = "돈길 리스트 가져오기")
     @GetMapping(produces = "application/json; charset=utf-8")
     public CommonResponse<List<ChallengeDTO>> getListChallenge(
-        @AuthenticationPrincipal User authUser) {
+        @AuthenticationPrincipal User authUser, @RequestParam String status) {
 
-        List<ChallengeDTO> challengeList = challengeService.readChallenge(authUser);
+        List<ChallengeDTO> challengeList = challengeService.readChallenge(authUser, status);
 
         return CommonResponse.onSuccess(challengeList);
     }

--- a/src/main/java/com/ceos/bankids/controller/ProgressController.java
+++ b/src/main/java/com/ceos/bankids/controller/ProgressController.java
@@ -1,0 +1,36 @@
+package com.ceos.bankids.controller;
+
+import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.request.ProgressRequest;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.ProgressDTO;
+import com.ceos.bankids.service.ProgressServiceImpl;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/progress")
+@RequiredArgsConstructor
+public class ProgressController {
+
+    private final ProgressServiceImpl progressService;
+
+    @ApiOperation(value = "돈길 걷기")
+    @PatchMapping(value = "/{challengeId}", produces = "application/json; charset=utf-8")
+    public CommonResponse<ProgressDTO> patchProgress(@AuthenticationPrincipal User authUser,
+        @PathVariable Long challengeId, @RequestBody ProgressRequest progressRequest) {
+
+        ProgressDTO progressDTO = progressService.updateProgress(authUser, challengeId,
+            progressRequest);
+
+        return CommonResponse.onSuccess(progressDTO);
+    }
+}

--- a/src/main/java/com/ceos/bankids/controller/request/ProgressRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/ProgressRequest.java
@@ -1,0 +1,22 @@
+package com.ceos.bankids.controller.request;
+
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProgressRequest {
+
+    @ApiModelProperty(example = "1")
+    private Long weeks;
+}

--- a/src/main/java/com/ceos/bankids/domain/AbstractTimestamp.java
+++ b/src/main/java/com/ceos/bankids/domain/AbstractTimestamp.java
@@ -1,5 +1,6 @@
 package com.ceos.bankids.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.sql.Timestamp;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
@@ -16,9 +17,11 @@ public class AbstractTimestamp {
 
     @Column(nullable = false)
     @CreationTimestamp
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss", timezone = "Asia/Seoul")
     private Timestamp createdAt;
 
     @Column(nullable = false)
     @UpdateTimestamp
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss", timezone = "Asia/Seoul")
     private Timestamp updatedAt;
 }

--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -65,9 +66,11 @@ public class Challenge extends AbstractTimestamp {
     @JoinColumn(name = "challengeCategoryId", nullable = false)
     private ChallengeCategory challengeCategory;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "challenge")
     private List<Progress> progressList;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "challenge")
     private List<ChallengeUser> challengeUserList;
 

--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -74,6 +74,7 @@ public class Challenge extends AbstractTimestamp {
     @OneToMany(mappedBy = "challenge")
     private List<ChallengeUser> challengeUserList;
 
+    @JsonManagedReference
     @OneToOne(mappedBy = "challenge")
     private Comment comment;
 

--- a/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
+++ b/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -34,6 +35,7 @@ public class ChallengeUser extends AbstractTimestamp {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @JsonBackReference
     @ManyToOne
     @JoinColumn(name = "challengeId", nullable = false)
     private Challenge challenge;

--- a/src/main/java/com/ceos/bankids/domain/Comment.java
+++ b/src/main/java/com/ceos/bankids/domain/Comment.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -30,6 +31,7 @@ public class Comment {
     @Column(nullable = false)
     private String content;
 
+    @JsonBackReference
     @OneToOne
     @JoinColumn(name = "challengeId", nullable = false)
     private Challenge challenge;

--- a/src/main/java/com/ceos/bankids/domain/Progress.java
+++ b/src/main/java/com/ceos/bankids/domain/Progress.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -35,6 +36,7 @@ public class Progress extends AbstractTimestamp {
     @ColumnDefault("false") //default value: false
     private Boolean isAchieved;
 
+    @JsonBackReference
     @ManyToOne
     @JoinColumn(name = "challengeId", nullable = false)
     private Challenge challenge;

--- a/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.dto;
 
 import com.ceos.bankids.domain.Challenge;
+import com.ceos.bankids.domain.Comment;
 import com.ceos.bankids.domain.Progress;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
@@ -46,6 +47,8 @@ public class ChallengeDTO {
 
     private List<Progress> progressList;
 
+    private Comment comment;
+
     public ChallengeDTO(Challenge challenge) {
         this.id = challenge.getId();
         this.title = challenge.getTitle();
@@ -57,5 +60,6 @@ public class ChallengeDTO {
         this.createdAt = challenge.getCreatedAt();
         this.status = challenge.getStatus();
         this.progressList = challenge.getProgressList();
+        this.comment = challenge.getComment();
     }
 }

--- a/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
@@ -1,13 +1,14 @@
 package com.ceos.bankids.dto;
 
 import com.ceos.bankids.domain.Challenge;
+import com.ceos.bankids.domain.Progress;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
+import java.sql.Timestamp;
+import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.sql.Timestamp;
 
 
 @Getter
@@ -43,6 +44,8 @@ public class ChallengeDTO {
     @ApiModelProperty(example = "1")
     private Long status;
 
+    private List<Progress> progressList;
+
     public ChallengeDTO(Challenge challenge) {
         this.id = challenge.getId();
         this.title = challenge.getTitle();
@@ -53,5 +56,6 @@ public class ChallengeDTO {
         this.weeks = challenge.getWeeks();
         this.createdAt = challenge.getCreatedAt();
         this.status = challenge.getStatus();
+        this.progressList = challenge.getProgressList();
     }
 }

--- a/src/main/java/com/ceos/bankids/dto/ProgressDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ProgressDTO.java
@@ -1,0 +1,32 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.Progress;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class ProgressDTO {
+
+    @ApiModelProperty(example = "1")
+    private Long id;
+
+    @ApiModelProperty(example = "2")
+    private Long challengeId;
+
+    @ApiModelProperty(example = "1")
+    private Long weeks;
+
+    @ApiModelProperty(example = "true")
+    private Boolean isAchieved;
+
+    public ProgressDTO(Progress progress) {
+        this.id = progress.getId();
+        this.challengeId = progress.getChallenge().getId();
+        this.weeks = progress.getWeeks();
+        this.isAchieved = progress.getIsAchieved();
+    }
+}

--- a/src/main/java/com/ceos/bankids/repository/ProgressRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/ProgressRepository.java
@@ -1,11 +1,14 @@
 package com.ceos.bankids.repository;
 
 import com.ceos.bankids.domain.Progress;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProgressRepository extends JpaRepository<Progress, Long> {
 
-    public Optional<Progress> findByChallengeId(Long challengeId);
+    public List<Progress> findByChallengeId(Long challengeId);
+
+    public Optional<Progress> findByChallengeIdAndWeeks(Long challengeId, Long weeks);
 
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeService.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeService.java
@@ -15,6 +15,6 @@ public interface ChallengeService {
 
     public ChallengeDTO deleteChallenge(User user, Long challengeId);
 
-    public List<ChallengeDTO> readChallenge(User user);
+    public List<ChallengeDTO> readChallenge(User user, String status);
 
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -115,13 +115,19 @@ public class ChallengeServiceImpl implements ChallengeService {
 
     @Transactional
     @Override
-    public List<ChallengeDTO> readChallenge(User user) {
+    public List<ChallengeDTO> readChallenge(User user, String status) {
 
         List<ChallengeUser> challengeUserRow = challengeUserRepository.findByUserId(
             user.getId());
         List<ChallengeDTO> challengeDTOList = new ArrayList<>();
         for (ChallengeUser r : challengeUserRow) {
-            challengeDTOList.add(new ChallengeDTO(r.getChallenge()));
+            if (status.equals("accept") && r.getChallenge().getStatus() == 2L) {
+                challengeDTOList.add(new ChallengeDTO(r.getChallenge()));
+            } else if ((status.equals("pending") || status.equals("reject"))
+                && r.getChallenge().getStatus() != 2L) {
+                challengeDTOList.add(new ChallengeDTO(r.getChallenge()));
+            }
+
         }
         return challengeDTOList;
     }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -60,6 +60,13 @@ public class ChallengeServiceImpl implements ChallengeService {
             .status(1L).interestRate(challengeRequest.getInterestRate())
             .challengeCategory(challengeCategory).targetItem(targetItem).build();
         challengeRepository.save(newChallenge);
+
+        for (int i = 0; i < challengeRequest.getWeeks(); i++) {
+            Progress newProgress = Progress.builder().weeks(Long.valueOf(i)).challenge(newChallenge)
+                .isAchieved(false).build();
+            progressRepository.save(newProgress);
+        }
+
         //ChallengeUser에 등록
         //ToDo: 자식-부모 매핑되면 부모도 같이 등록시키기
         ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
@@ -101,6 +108,7 @@ public class ChallengeServiceImpl implements ChallengeService {
             }
             List<Progress> progressList = deleteChallenge.getProgressList();
             if ((long) progressList.size() == 1 || progressList.isEmpty()) {
+                progressRepository.deleteAll(progressList);
                 challengeUserRepository.delete(deleteChallengeUser);
                 challengeRepository.delete(deleteChallenge);
             } else {

--- a/src/main/java/com/ceos/bankids/service/ProgressService.java
+++ b/src/main/java/com/ceos/bankids/service/ProgressService.java
@@ -1,0 +1,12 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.controller.request.ProgressRequest;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.ProgressDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ProgressService {
+
+    public ProgressDTO updateProgress(User user, Long challengeId, ProgressRequest progressRequest);
+}

--- a/src/main/java/com/ceos/bankids/service/ProgressServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ProgressServiceImpl.java
@@ -1,0 +1,46 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.controller.request.ProgressRequest;
+import com.ceos.bankids.domain.ChallengeUser;
+import com.ceos.bankids.domain.Progress;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.ProgressDTO;
+import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.exception.ForbiddenException;
+import com.ceos.bankids.repository.ChallengeUserRepository;
+import com.ceos.bankids.repository.ProgressRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ProgressServiceImpl implements ProgressService {
+
+    private final ProgressRepository progressRepository;
+    private final ChallengeUserRepository challengeUserRepository;
+
+    @Override
+    public ProgressDTO updateProgress(User user, Long challengeId,
+        ProgressRequest progressRequest) {
+
+        Long weeks = progressRequest.getWeeks();
+        Optional<Progress> progress = progressRepository.findByChallengeIdAndWeeks(
+            challengeId, weeks);
+        Optional<ChallengeUser> challengeUser = challengeUserRepository.findByChallengeId(
+            challengeId);
+        challengeUser.ifPresent(c -> {
+            if (!c.getUser().equals(user)) {
+                throw new ForbiddenException("접근 할 수 없는 돈길입니다.");
+            }
+        });
+        if (progress.isPresent()) {
+            progress.ifPresent(p -> p.setIsAchieved(true));
+            return new ProgressDTO(progress.get());
+        } else {
+            throw new BadRequestException("존재하지 않는 프로그레스 입니다.");
+        }
+    }
+}

--- a/src/main/java/com/ceos/bankids/service/ProgressServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ProgressServiceImpl.java
@@ -37,7 +37,10 @@ public class ProgressServiceImpl implements ProgressService {
             }
         });
         if (progress.isPresent()) {
-            progress.ifPresent(p -> p.setIsAchieved(true));
+            progress.ifPresent(p -> {
+                p.setIsAchieved(true);
+                progressRepository.save(p);
+            });
             return new ProgressDTO(progress.get());
         } else {
             throw new BadRequestException("존재하지 않는 프로그레스 입니다.");

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -792,7 +792,7 @@ public class ChallengeControllerTest {
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
             mockProgressRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
-        CommonResponse result = challengeController.getListChallenge(newUser);
+        CommonResponse result = challengeController.getListChallenge(newUser, "pending");
 
         //then
         List<ChallengeDTO> challengeDTOList = new ArrayList<>();
@@ -836,7 +836,7 @@ public class ChallengeControllerTest {
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
             mockProgressRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
-        CommonResponse result = challengeController.getListChallenge(newUser);
+        CommonResponse result = challengeController.getListChallenge(newUser, "pending");
 
         //then
         List<ChallengeDTO> challengeDTOList = new ArrayList<>();

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -762,7 +762,7 @@ public class ChallengeControllerTest {
         Challenge newChallenge1 = Challenge.builder().title(challengeRequest1.getTitle())
             .isAchieved(false).totalPrice(challengeRequest1.getTotalPrice())
             .weekPrice(challengeRequest1.getWeekPrice()).weeks(challengeRequest1.getWeeks())
-            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
             .interestRate(challengeRequest1.getInterestRate()).build();
 
         ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
@@ -793,15 +793,25 @@ public class ChallengeControllerTest {
             mockProgressRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.getListChallenge(newUser, "pending");
+        CommonResponse result1 = challengeController.getListChallenge(newUser, "accept");
 
         //then
         List<ChallengeDTO> challengeDTOList = new ArrayList<>();
+        List<ChallengeDTO> challengeDTOList1 = new ArrayList<>();
         for (ChallengeUser r : challengeUserList) {
-            challengeDTOList.add(new ChallengeDTO(r.getChallenge()));
+            if (r.getChallenge().getStatus() != 2L) {
+                challengeDTOList.add(new ChallengeDTO(r.getChallenge()));
+
+            } else {
+                challengeDTOList1.add(new ChallengeDTO(r.getChallenge()));
+            }
         }
 
         Assertions.assertEquals(CommonResponse.onSuccess(challengeDTOList).getData(),
             result.getData());
+        Assertions.assertEquals(CommonResponse.onSuccess(challengeDTOList1).getData(),
+            result1.getData());
+
     }
 
     @Test

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -161,6 +161,76 @@ public class ChallengeControllerTest {
     }
 
     @Test
+    @DisplayName("챌린지 생성 시, 챌린지에 걸리는 progress 정상 생성 테스트")
+    public void testMakeProgress() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+            5000L, 1000L, 5L);
+
+        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
+            .category("이자율 받기").build();
+
+        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
+
+        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
+            .member("parent").user(newUser).build();
+
+        List<Progress> progressList = new ArrayList<>();
+        for (int i = 0; i < challengeRequest.getWeeks(); i++) {
+            Progress newProgress = Progress.builder().challenge(newChallenge).isAchieved(false)
+                .weeks(Long.valueOf(i)).build();
+            progressList.add(newProgress);
+        }
+
+        Mockito.when(mockChallengeRepository.save(newChallenge)).thenReturn(newChallenge);
+        Mockito.when(mockChallengeRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(newChallenge));
+        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
+            .thenReturn(newTargetItem);
+        Mockito.when(
+                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
+            .thenReturn(newChallengeCategory);
+        Mockito.when(mockChallengeUserRepository.save(newChallengeUser))
+            .thenReturn(newChallengeUser);
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+        Mockito.when(mockProgressRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(progressList);
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
+            mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
+            mockProgressRepository);
+        ChallengeController challengeController = new ChallengeController(challengeService);
+        CommonResponse result = challengeController.postChallenge(newUser, challengeRequest,
+            mockBindingResult);
+
+        //then
+        ChallengeDTO challengeDTO = new ChallengeDTO(newChallenge);
+
+        Assertions.assertEquals(CommonResponse.onSuccess(challengeDTO), result);
+    }
+
+    @Test
     @DisplayName("챌린지 생성 시, 목표 아이템 입력 400 에러 테스트")
     public void testIfMakeChallengeTargetItemBadRequestErr() {
 

--- a/src/test/java/com/ceos/bankids/unit/controller/ProgressControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ProgressControllerTest.java
@@ -1,0 +1,5 @@
+package com.ceos.bankids.unit.controller;
+
+public class ProgressControllerTest {
+
+}

--- a/src/test/java/com/ceos/bankids/unit/controller/ProgressControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ProgressControllerTest.java
@@ -1,5 +1,245 @@
 package com.ceos.bankids.unit.controller;
 
+import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.ProgressController;
+import com.ceos.bankids.controller.request.ChallengeRequest;
+import com.ceos.bankids.controller.request.ProgressRequest;
+import com.ceos.bankids.domain.Challenge;
+import com.ceos.bankids.domain.ChallengeCategory;
+import com.ceos.bankids.domain.ChallengeUser;
+import com.ceos.bankids.domain.Progress;
+import com.ceos.bankids.domain.TargetItem;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.ProgressDTO;
+import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.exception.ForbiddenException;
+import com.ceos.bankids.repository.ChallengeCategoryRepository;
+import com.ceos.bankids.repository.ChallengeRepository;
+import com.ceos.bankids.repository.ChallengeUserRepository;
+import com.ceos.bankids.repository.ProgressRepository;
+import com.ceos.bankids.repository.TargetItemRepository;
+import com.ceos.bankids.service.ProgressServiceImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
 public class ProgressControllerTest {
 
+    @Test
+    @DisplayName("돈길 걷기 요청 시, 프로그레스의 row가 정상적으로 업데이트 되는지 테스트")
+    public void testIfSavingsProgressRowUpdate() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+            150000L, 10000L, 15L);
+
+        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
+            .category("이자율 받기").build();
+
+        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
+
+        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
+            .member("parent").user(newUser).build();
+
+        Progress newProgress = Progress.builder()
+            .id(1L)
+            .challenge(newChallenge)
+            .weeks(1L)
+            .isAchieved(false)
+            .build();
+
+        Mockito.when(mockChallengeRepository.save(newChallenge)).thenReturn(newChallenge);
+        Mockito.when(mockChallengeRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(newChallenge));
+        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
+            .thenReturn(newTargetItem);
+        Mockito.when(
+                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
+            .thenReturn(newChallengeCategory);
+        Mockito.when(mockChallengeUserRepository.save(newChallengeUser))
+            .thenReturn(newChallengeUser);
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+        Mockito.when(mockProgressRepository.findByChallengeIdAndWeeks(newChallenge.getId(), 1L))
+            .thenReturn(Optional.ofNullable(newProgress));
+
+        //when
+        ProgressRequest progressRequest = new ProgressRequest(1L);
+        ProgressServiceImpl progressService = new ProgressServiceImpl(mockProgressRepository,
+            mockChallengeUserRepository);
+        ProgressController progressController = new ProgressController(progressService);
+        ProgressDTO progressDTO = new ProgressDTO(newProgress);
+        CommonResponse result = progressController.patchProgress(newUser, newChallenge.getId(),
+            progressRequest);
+
+        //then
+        ArgumentCaptor<Long> pCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Long> wCaptor = ArgumentCaptor.forClass(Long.class);
+
+        Mockito.verify(mockProgressRepository, Mockito.times(1))
+            .findByChallengeIdAndWeeks(pCaptor.capture(), wCaptor.capture());
+
+        Assertions.assertEquals(newProgress.getChallenge().getId(), pCaptor.getValue());
+        Assertions.assertEquals(newProgress.getWeeks(), wCaptor.getValue());
+
+        Assertions.assertNotEquals(progressDTO, result.getData());
+    }
+
+    @Test
+    @DisplayName("돈길 걷기 요청 시, 챌린지를 만든 유저가 아닐 때 403 에러 테스트")
+    public void testIfSavingsNotProgressUserForbbidenErr() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+            150000L, 10000L, 15L);
+
+        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newUser1 = User.builder().id(2L).username("user").isFemale(true).birthday("19990623")
+            .authenticationCode("code1").provider("kakao").isKid(true).refreshToken("token1")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
+            .category("이자율 받기").build();
+
+        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
+
+        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
+            .member("parent").user(newUser).build();
+
+        Progress newProgress = Progress.builder()
+            .id(1L)
+            .challenge(newChallenge)
+            .weeks(1L)
+            .isAchieved(false)
+            .build();
+
+        Mockito.when(mockChallengeRepository.save(newChallenge)).thenReturn(newChallenge);
+        Mockito.when(mockChallengeRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(newChallenge));
+        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
+            .thenReturn(newTargetItem);
+        Mockito.when(
+                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
+            .thenReturn(newChallengeCategory);
+        Mockito.when(mockChallengeUserRepository.save(newChallengeUser))
+            .thenReturn(newChallengeUser);
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+        Mockito.when(mockProgressRepository.findByChallengeIdAndWeeks(newChallenge.getId(), 1L))
+            .thenReturn(Optional.ofNullable(newProgress));
+
+        //when
+        ProgressRequest progressRequest = new ProgressRequest(1L);
+        ProgressServiceImpl progressService = new ProgressServiceImpl(mockProgressRepository,
+            mockChallengeUserRepository);
+        ProgressController progressController = new ProgressController(progressService);
+
+        //then
+        Assertions.assertThrows(ForbiddenException.class,
+            () -> progressController.patchProgress(newUser1, newChallenge.getId(),
+                progressRequest));
+    }
+
+    @Test
+    @DisplayName("돈길 걷기 요청 시, 아직 생성되지 않은 주차의 프로그레스라면 400 에러 테스트")
+    public void testIfSavingsNotExistProgressBadRequestErr() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+            150000L, 10000L, 15L);
+
+        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
+            .category("이자율 받기").build();
+
+        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
+
+        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
+            .member("parent").user(newUser).build();
+
+        Progress newProgress = Progress.builder()
+            .id(1L)
+            .challenge(newChallenge)
+            .weeks(1L)
+            .isAchieved(false)
+            .build();
+
+        Mockito.when(mockChallengeRepository.save(newChallenge)).thenReturn(newChallenge);
+        Mockito.when(mockChallengeRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(newChallenge));
+        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
+            .thenReturn(newTargetItem);
+        Mockito.when(
+                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
+            .thenReturn(newChallengeCategory);
+        Mockito.when(mockChallengeUserRepository.save(newChallengeUser))
+            .thenReturn(newChallengeUser);
+        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
+            .thenReturn(Optional.ofNullable(newChallengeUser));
+        Mockito.when(mockProgressRepository.findByChallengeIdAndWeeks(newChallenge.getId(), 1L))
+            .thenReturn(Optional.ofNullable(newProgress));
+
+        //when
+        ProgressRequest progressRequest = new ProgressRequest(2L);
+        ProgressServiceImpl progressService = new ProgressServiceImpl(mockProgressRepository,
+            mockChallengeUserRepository);
+        ProgressController progressController = new ProgressController(progressService);
+
+        //then
+        Assertions.assertThrows(BadRequestException.class,
+            () -> progressController.patchProgress(newUser, newChallenge.getId(),
+                progressRequest));
+    }
 }


### PR DESCRIPTION
## 📝 PR Summary

* 돈길 걷기 API는 주차 정보가 미리 생성되어있는 관계로 Requestbody에 몇 주차인지 넘겨받는 형식으로 작성했습니다.
* Patch 메서드 사용해서 Progress 테이블의  row 하나의 isAchieved 컬럼을 true로 바꿔주는 API 입니다.
* 돈길 상세 조회 쪽에서 빠져있던 프로그레스 정보들을 리스트로 넘겨주었습니다.
    *  이 과정에서 순환참조가 발생해서 깜짝놀랐는데 @JsonBackReference / @JsonManagedReference를 달아주면서 해결 할 수 있었습니다.
* 프론트 측의 협의하에 돈길 리스트 조회 API에도 프로그레스 정보를 달아주었습니다.
#### 🌲 Working Branch

* feature/savings
#### 🌲 TODOs

* 현재 자동 프로그레스 생성 기준이 돈길 생성 시 로 되어있는데 해당 기준을 부모가 요청 수락 시 로 바꿔야 할 것 같습니다.
* 따라서 부모의 요청 수락 API가 필요한데 가족 생성 API를 pull 하고 가져가기 위해 먼저 커밋 날리고 땡길 예정입니다.
### Related Issues

#25 