### PR TITLE
feat: 가족 정보 조회

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/FamilyController.java
+++ b/src/main/java/com/ceos/bankids/controller/FamilyController.java
@@ -22,10 +22,11 @@ public class FamilyController {
 
     @PostMapping(value = "", produces = "application/json; charset=utf-8")
     @ResponseBody
-    public CommonResponse<FamilyDTO> postNewFamily(@AuthenticationPrincipal User authUser) {
+    public CommonResponse<FamilyDTO> postFamily(@AuthenticationPrincipal User authUser) {
 
         FamilyDTO familyDTO = familyService.postNewFamily(authUser);
 
         return CommonResponse.onSuccess(familyDTO);
     }
+
 }

--- a/src/main/java/com/ceos/bankids/controller/FamilyController.java
+++ b/src/main/java/com/ceos/bankids/controller/FamilyController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -29,4 +30,12 @@ public class FamilyController {
         return CommonResponse.onSuccess(familyDTO);
     }
 
+    @GetMapping(value = "", produces = "application/json; charset=utf-8")
+    @ResponseBody
+    public CommonResponse<FamilyDTO> getFamily(@AuthenticationPrincipal User authUser) {
+
+        FamilyDTO familyDTO = familyService.getFamily(authUser);
+
+        return CommonResponse.onSuccess(familyDTO);
+    }
 }

--- a/src/main/java/com/ceos/bankids/service/FamilyService.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyService.java
@@ -14,4 +14,5 @@ public interface FamilyService {
 
     public List<FamilyUserDTO> getFamilyUserList(Family family);
 
+    public FamilyDTO getFamily(User user);
 }

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -8,6 +8,7 @@ import com.ceos.bankids.dto.FamilyUserDTO;
 import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.repository.FamilyRepository;
 import com.ceos.bankids.repository.FamilyUserRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -59,7 +60,7 @@ public class FamilyServiceImpl implements FamilyService {
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public List<FamilyUserDTO> getFamilyUserList(Family family) {
         List<FamilyUser> familyUser = fuRepo.findByFamily(family);
 
@@ -68,5 +69,21 @@ public class FamilyServiceImpl implements FamilyService {
             .collect(Collectors.toList());
 
         return userDTOList;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public FamilyDTO getFamily(User user) {
+        Optional<FamilyUser> familyUser = fuRepo.findByUserId(user.getId());
+        if (familyUser.isPresent()) {
+            Family family = familyUser.get().getFamily();
+            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(family);
+            FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
+            return familyDTO;
+        } else {
+            Family family = new Family();
+            FamilyDTO familyDTO = new FamilyDTO(family, new ArrayList<>());
+            return familyDTO;
+        }
     }
 }

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -76,13 +76,15 @@ public class FamilyServiceImpl implements FamilyService {
     public FamilyDTO getFamily(User user) {
         Optional<FamilyUser> familyUser = fuRepo.findByUserId(user.getId());
         if (familyUser.isPresent()) {
-            Family family = familyUser.get().getFamily();
-            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(family);
-            FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
+            Optional<Family> family = fRepo.findById(familyUser.get().getFamily().getId());
+            if (family.isEmpty()) {
+                throw new BadRequestException("삭제된 가족입니다.");
+            }
+            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(family.get());
+            FamilyDTO familyDTO = new FamilyDTO(family.get(), familyUserDTOList);
             return familyDTO;
         } else {
-            Family family = new Family();
-            FamilyDTO familyDTO = new FamilyDTO(family, new ArrayList<>());
+            FamilyDTO familyDTO = new FamilyDTO(new Family(), new ArrayList<>());
             return familyDTO;
         }
     }

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -33,7 +33,6 @@ public class KakaoServiceImpl implements KakaoService {
     private String KAKAO_URI;
 
     @Override
-    @Transactional
     public KakaoTokenDTO getKakaoAccessToken(KakaoRequest kakaoRequest) {
         String getTokenURL =
             "https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id="
@@ -49,7 +48,6 @@ public class KakaoServiceImpl implements KakaoService {
     }
 
     @Override
-    @Transactional
     public KakaoUserDTO getKakaoUserCode(KakaoTokenDTO kakaoTokenDTO) {
         String getUserURL = "https://kapi.kakao.com/v2/user/me";
 

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -24,8 +24,8 @@ import org.mockito.Mockito;
 public class FamilyControllerTest {
 
     @Test
-    @DisplayName("기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
-    public void testIfFamilyExistButDeletedThenThrowBadRequestException() {
+    @DisplayName("생성 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
+    public void testIfFamilyExistButDeletedWhenPostThenThrowBadRequestException() {
         // given
         User user1 = User.builder()
             .id(1L)
@@ -75,8 +75,8 @@ public class FamilyControllerTest {
     }
 
     @Test
-    @DisplayName("기존 가족 있을 때, 가족 정보 반환하는지 확인")
-    public void testIfFamilyExistThenReturnResult() {
+    @DisplayName("생성 시 기존 가족 있을 때, 가족 정보 반환하는지 확인")
+    public void testIfFamilyExistThenReturnPostResult() {
         // given
         User user1 = User.builder()
             .id(1L)
@@ -128,7 +128,7 @@ public class FamilyControllerTest {
     }
 
     @Test
-    @DisplayName("기존 가족 없을 때, 가족 생성 후 정보 반환하는지 확인")
+    @DisplayName("생성 시 기존 가족 없을 때, 가족 생성 후 정보 반환하는지 확인")
     public void testIfFamilyNotExistThenPostAndReturnResult() {
         // given
         User user1 = User.builder()
@@ -178,5 +178,144 @@ public class FamilyControllerTest {
         FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
 
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("조회 시 기존 가족 있을 때, 가족 정보 반환하는지 확인")
+    public void testIfFamilyExistThenReturnGetResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+        CommonResponse<FamilyDTO> result = familyController.getFamily(user1);
+
+        // then
+        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
+            .map(FamilyUserDTO::new).collect(Collectors.toList());
+        FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("조회 시 기존 가족 없을 때, 빈 가족 정보 반환하는지 확인")
+    public void testIfFamilyNotExistThenReturnGetResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+        CommonResponse<FamilyDTO> result = familyController.getFamily(user1);
+
+        // then
+        FamilyDTO familyDTO = new FamilyDTO(new Family(), new ArrayList<>());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("조회 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
+    public void testIfFamilyExistButDeletedWhenGetThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.getFamily(user1);
+        });
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -70,7 +70,7 @@ public class FamilyControllerTest {
 
         // then
         Assertions.assertThrows(BadRequestException.class, () -> {
-            familyController.postNewFamily(user1);
+            familyController.postFamily(user1);
         });
     }
 
@@ -118,7 +118,7 @@ public class FamilyControllerTest {
         FamilyController familyController = new FamilyController(
             familyService
         );
-        CommonResponse<FamilyDTO> result = familyController.postNewFamily(user1);
+        CommonResponse<FamilyDTO> result = familyController.postFamily(user1);
 
         // then
         List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
@@ -160,7 +160,7 @@ public class FamilyControllerTest {
         FamilyController familyController = new FamilyController(
             familyService
         );
-        CommonResponse<FamilyDTO> result = familyController.postNewFamily(user1);
+        CommonResponse<FamilyDTO> result = familyController.postFamily(user1);
         String code = result.getData().getCode();
         family.setCode(code);
 


### PR DESCRIPTION
## 📝 PR Summary
- 마이페이지 가족 정보 가져오기 API 제작했습니다.
- 가족 없을 시에도 빈 FamilyDTO 만들어 반환했습니다.
- 가족 중 일부가 탈퇴할 경우, 탈퇴 시점에 가족에서 제거할 예정입니다.
- 카카오 API에서는 DB 조회하지 않아 Transactional 어노테이션 제거했습니다.
- 함수명 형식 통일 위해 기존 함수 이름 변경했습니다.

<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/family
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] 가족 있을 시 가족 정보 반환
- [x] 가족 없을 시 빈 가족 정보 반환
- [x] 테스트 코드
- [x] 기존 api 불필요 어노테이션 삭제
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#29
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
