### PR TITLE
feat: 자녀 돈길 조회 API 및 자녀 요청 수락/거절 API

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/ChallengeController.java
+++ b/src/main/java/com/ceos/bankids/controller/ChallengeController.java
@@ -4,6 +4,7 @@ import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.ChallengeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.ChallengeDTO;
+import com.ceos.bankids.dto.KidChallengeListDTO;
 import com.ceos.bankids.service.ChallengeServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;
@@ -66,5 +67,15 @@ public class ChallengeController {
         List<ChallengeDTO> challengeList = challengeService.readChallenge(authUser, status);
 
         return CommonResponse.onSuccess(challengeList);
+    }
+
+    @ApiOperation(value = "자녀의 돈길 리스트 가져오기")
+    @GetMapping(value = "/kid", produces = "application/json; charset=utf-8")
+    public CommonResponse<List<KidChallengeListDTO>> getListKidChallenge(
+        @AuthenticationPrincipal User authUser) {
+
+        List<KidChallengeListDTO> kidChallengeList = challengeService.readKidChallenge(authUser);
+
+        return CommonResponse.onSuccess(kidChallengeList);
     }
 }

--- a/src/main/java/com/ceos/bankids/controller/ChallengeController.java
+++ b/src/main/java/com/ceos/bankids/controller/ChallengeController.java
@@ -77,7 +77,7 @@ public class ChallengeController {
         @AuthenticationPrincipal User authUser) {
 
         List<KidChallengeListDTO> kidChallengeList = challengeService.readKidChallenge(authUser);
-
+        
         return CommonResponse.onSuccess(kidChallengeList);
     }
 

--- a/src/main/java/com/ceos/bankids/controller/ChallengeController.java
+++ b/src/main/java/com/ceos/bankids/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.ChallengeRequest;
+import com.ceos.bankids.controller.request.KidChallengeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.ChallengeDTO;
 import com.ceos.bankids.dto.KidChallengeListDTO;
@@ -15,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -77,5 +79,17 @@ public class ChallengeController {
         List<KidChallengeListDTO> kidChallengeList = challengeService.readKidChallenge(authUser);
 
         return CommonResponse.onSuccess(kidChallengeList);
+    }
+
+    @ApiOperation(value = "자녀의 돈길 수락 / 거절")
+    @PatchMapping(value = "/{challengeId}", produces = "application/json; charset=utf-8")
+    public CommonResponse<ChallengeDTO> patchChallengeStatus(@AuthenticationPrincipal User authUser,
+        @PathVariable Long challengeId,
+        @Valid @RequestBody KidChallengeRequest kidChallengeRequest) {
+
+        ChallengeDTO challengeDTO = challengeService.updateChallengeStatus(authUser, challengeId,
+            kidChallengeRequest);
+
+        return CommonResponse.onSuccess(challengeDTO);
     }
 }

--- a/src/main/java/com/ceos/bankids/controller/request/KidChallengeRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/KidChallengeRequest.java
@@ -1,5 +1,6 @@
 package com.ceos.bankids.controller.request;
 
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,8 +17,10 @@ import lombok.Setter;
 @Builder
 public class KidChallengeRequest {
 
+    @ApiModelProperty(example = "false")
     @NotNull(message = "돈길 수락 여부를 입력해주세요")
     private Boolean accept;
 
+    @ApiModelProperty(example = "아쉽구나...")
     private String comment;
 }

--- a/src/main/java/com/ceos/bankids/controller/request/KidChallengeRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/KidChallengeRequest.java
@@ -1,0 +1,23 @@
+package com.ceos.bankids.controller.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KidChallengeRequest {
+
+    @NotNull(message = "돈길 수락 여부를 입력해주세요")
+    private Boolean accept;
+
+    private String comment;
+}

--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.util.List;
 import javax.persistence.Column;
@@ -58,10 +59,12 @@ public class Challenge extends AbstractTimestamp {
     @Column(nullable = false)
     private Long interestRate;
 
+    @JsonBackReference
     @ManyToOne
     @JoinColumn(name = "targetItemId", nullable = false)
     private TargetItem targetItem;
 
+    @JsonBackReference
     @ManyToOne
     @JoinColumn(name = "challengeCategoryId", nullable = false)
     private ChallengeCategory challengeCategory;

--- a/src/main/java/com/ceos/bankids/domain/ChallengeCategory.java
+++ b/src/main/java/com/ceos/bankids/domain/ChallengeCategory.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -32,6 +33,7 @@ public class ChallengeCategory extends AbstractTimestamp {
     @Column(nullable = false, unique = true)
     private String category;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "challengeCategory")
     private List<Challenge> challengeList;
 

--- a/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
+++ b/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
@@ -31,6 +31,7 @@ public class ChallengeUser extends AbstractTimestamp {
     @Column(nullable = false)
     private String member;
 
+    @JsonBackReference
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/src/main/java/com/ceos/bankids/domain/Comment.java
+++ b/src/main/java/com/ceos/bankids/domain/Comment.java
@@ -8,6 +8,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.Builder;
@@ -36,11 +37,17 @@ public class Comment {
     @JoinColumn(name = "challengeId", nullable = false)
     private Challenge challenge;
 
+    @JsonBackReference
+    @ManyToOne
+    @JoinColumn(name = "userId", nullable = false)
+    private User user;
+
     @Builder
     public Comment(
         Long id,
         String content,
-        Challenge challenge
+        Challenge challenge,
+        User user
     ) {
         if (content == null) {
             throw new BadRequestException("내용은 필수값입니다.");
@@ -48,8 +55,12 @@ public class Comment {
         if (challenge == null) {
             throw new BadRequestException("챌린지는 필수값입니다.");
         }
+        if (user == null) {
+            throw new BadRequestException("유저는 필수값입니다.");
+        }
         this.id = id;
         this.content = content;
         this.challenge = challenge;
+        this.user = user;
     }
 }

--- a/src/main/java/com/ceos/bankids/domain/TargetItem.java
+++ b/src/main/java/com/ceos/bankids/domain/TargetItem.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -32,6 +33,7 @@ public class TargetItem extends AbstractTimestamp {
     @Column(nullable = false)
     private String name;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "targetItem")
     private List<Challenge> challengeList;
 

--- a/src/main/java/com/ceos/bankids/domain/User.java
+++ b/src/main/java/com/ceos/bankids/domain/User.java
@@ -70,8 +70,13 @@ public class User extends AbstractTimestamp implements UserDetails {
     @OneToMany(mappedBy = "user")
     private List<ChallengeUser> challengeUserList;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "user")
     private List<FamilyUser> familyUserList;
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "user")
+    private List<Comment> commentList;
 
     @Builder
     public User(

--- a/src/main/java/com/ceos/bankids/domain/User.java
+++ b/src/main/java/com/ceos/bankids/domain/User.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +66,7 @@ public class User extends AbstractTimestamp implements UserDetails {
     @OneToOne(mappedBy = "user")
     private Parent parent;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "user")
     private List<ChallengeUser> challengeUserList;
 

--- a/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
@@ -45,6 +45,7 @@ public class ChallengeDTO {
     @ApiModelProperty(example = "1")
     private Long status;
 
+    @ApiModelProperty(example = "true")
     private List<Progress> progressList;
 
     private Comment comment;

--- a/src/main/java/com/ceos/bankids/dto/KidChallengeListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidChallengeListDTO.java
@@ -4,6 +4,7 @@ import com.ceos.bankids.domain.User;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,6 +13,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class KidChallengeListDTO {
 
     @ApiModelProperty(example = "test")

--- a/src/main/java/com/ceos/bankids/dto/KidChallengeListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidChallengeListDTO.java
@@ -1,0 +1,31 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.User;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KidChallengeListDTO {
+
+    @ApiModelProperty(example = "test")
+    private String userName;
+
+    @ApiModelProperty(example = "true")
+    private Boolean isFemale;
+
+    @ApiModelProperty(example = "true")
+    private List<ChallengeDTO> challengeList;
+
+    public KidChallengeListDTO(User user, List<ChallengeDTO> challengeList) {
+        this.userName = user.getUsername();
+        this.isFemale = user.getIsFemale();
+        this.challengeList = challengeList;
+    }
+}

--- a/src/main/java/com/ceos/bankids/repository/CommentRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.ceos.bankids.repository;
+
+import com.ceos.bankids.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/ceos/bankids/service/ChallengeService.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeService.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.service;
 
 import com.ceos.bankids.controller.request.ChallengeRequest;
+import com.ceos.bankids.controller.request.KidChallengeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.ChallengeDTO;
 import com.ceos.bankids.dto.KidChallengeListDTO;
@@ -19,5 +20,8 @@ public interface ChallengeService {
     public List<ChallengeDTO> readChallenge(User user, String status);
 
     public List<KidChallengeListDTO> readKidChallenge(User user);
+
+    public ChallengeDTO updateChallengeStatus(User user, Long challengeId,
+        KidChallengeRequest kidChallengeRequest);
 
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeService.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeService.java
@@ -3,6 +3,7 @@ package com.ceos.bankids.service;
 import com.ceos.bankids.controller.request.ChallengeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.ChallengeDTO;
+import com.ceos.bankids.dto.KidChallengeListDTO;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +17,7 @@ public interface ChallengeService {
     public ChallengeDTO deleteChallenge(User user, Long challengeId);
 
     public List<ChallengeDTO> readChallenge(User user, String status);
+
+    public List<KidChallengeListDTO> readKidChallenge(User user);
 
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -69,12 +69,6 @@ public class ChallengeServiceImpl implements ChallengeService {
             .challengeCategory(challengeCategory).targetItem(targetItem).build();
         challengeRepository.save(newChallenge);
 
-        for (int i = 0; i < challengeRequest.getWeeks(); i++) {
-            Progress newProgress = Progress.builder().weeks(Long.valueOf(i)).challenge(newChallenge)
-                .isAchieved(false).build();
-            progressRepository.save(newProgress);
-        }
-
         //ChallengeUser에 등록
         //ToDo: 자식-부모 매핑되면 부모도 같이 등록시키기
         ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
@@ -197,6 +191,12 @@ public class ChallengeServiceImpl implements ChallengeService {
         if (kidChallengeRequest.getAccept()) {
             challenge.setStatus(2L);
             challengeRepository.save(challenge);
+            for (int i = 1; i <= challenge.getWeeks(); i++) {
+                Progress newProgress = Progress.builder().weeks(Long.valueOf(i))
+                    .challenge(challenge)
+                    .isAchieved(false).build();
+                progressRepository.save(newProgress);
+            }
         } else {
             Comment newComment = Comment.builder().challenge(challenge).content(
                 kidChallengeRequest.getComment()).user(user).build();

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -169,6 +169,7 @@ public class ChallengeServiceImpl implements ChallengeService {
                 }
             });
         });
+
         return kidChallengeListDTOList;
     }
 
@@ -204,6 +205,7 @@ public class ChallengeServiceImpl implements ChallengeService {
             challenge.setComment(newComment);
             challengeRepository.save(challenge);
         }
+
         return new ChallengeDTO(challengeRepository.findById(challengeId).get());
     }
 

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -16,6 +16,7 @@ import com.ceos.bankids.exception.NotFoundException;
 import com.ceos.bankids.repository.ChallengeCategoryRepository;
 import com.ceos.bankids.repository.ChallengeRepository;
 import com.ceos.bankids.repository.ChallengeUserRepository;
+import com.ceos.bankids.repository.CommentRepository;
 import com.ceos.bankids.repository.FamilyUserRepository;
 import com.ceos.bankids.repository.ProgressRepository;
 import com.ceos.bankids.repository.TargetItemRepository;
@@ -47,6 +48,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
         //given
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
@@ -78,7 +80,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.postChallenge(newUser, challengeRequest,
             mockBindingResult);
@@ -106,6 +108,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
@@ -144,7 +147,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.postChallenge(newUser, challengeRequest,
             mockBindingResult);
@@ -176,6 +179,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
@@ -223,7 +227,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.postChallenge(newUser, challengeRequest,
             mockBindingResult);
@@ -247,6 +251,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "선물", "에어팟 사기", 30L,
@@ -273,7 +278,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
 
         //then
@@ -295,6 +300,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("형제와 경쟁 하기", "전자제품", "에어팟 사기", 30L,
@@ -322,7 +328,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
 
         //then
@@ -345,6 +351,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
@@ -372,7 +379,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
 
         //then
@@ -395,6 +402,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -432,7 +440,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
         CommonResponse result = challengeController.getChallenge(newUser, challengeId);
@@ -462,6 +470,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -492,7 +501,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -517,6 +526,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -550,7 +560,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -573,6 +583,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -613,7 +624,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
         CommonResponse result = challengeController.deleteChallenge(newUser, challengeId);
@@ -645,6 +656,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -675,7 +687,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -700,6 +712,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -736,7 +749,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -759,6 +772,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -792,7 +806,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -815,6 +829,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -867,7 +882,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.getListChallenge(newUser, "pending");
         CommonResponse result1 = challengeController.getListChallenge(newUser, "accept");
@@ -904,6 +919,7 @@ public class ChallengeControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
@@ -921,7 +937,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository);
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.getListChallenge(newUser, "pending");
 

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -16,6 +16,7 @@ import com.ceos.bankids.exception.NotFoundException;
 import com.ceos.bankids.repository.ChallengeCategoryRepository;
 import com.ceos.bankids.repository.ChallengeRepository;
 import com.ceos.bankids.repository.ChallengeUserRepository;
+import com.ceos.bankids.repository.FamilyUserRepository;
 import com.ceos.bankids.repository.ProgressRepository;
 import com.ceos.bankids.repository.TargetItemRepository;
 import com.ceos.bankids.repository.UserRepository;
@@ -45,6 +46,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
         //given
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
@@ -76,7 +78,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.postChallenge(newUser, challengeRequest,
             mockBindingResult);
@@ -103,6 +105,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
@@ -141,7 +144,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.postChallenge(newUser, challengeRequest,
             mockBindingResult);
@@ -172,6 +175,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
@@ -219,7 +223,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.postChallenge(newUser, challengeRequest,
             mockBindingResult);
@@ -242,6 +246,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "선물", "에어팟 사기", 30L,
@@ -268,7 +273,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
 
         //then
@@ -289,6 +294,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("형제와 경쟁 하기", "전자제품", "에어팟 사기", 30L,
@@ -316,7 +322,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
 
         //then
@@ -338,6 +344,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
@@ -365,7 +372,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
 
         //then
@@ -387,7 +394,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -425,7 +432,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
         CommonResponse result = challengeController.getChallenge(newUser, challengeId);
@@ -454,7 +461,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -485,7 +492,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -509,7 +516,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -543,7 +550,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -565,7 +572,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -606,7 +613,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
         CommonResponse result = challengeController.deleteChallenge(newUser, challengeId);
@@ -637,7 +644,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -668,7 +675,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -692,7 +699,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -729,7 +736,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -751,7 +758,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -785,7 +792,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         Long challengeId = newChallenge.getId();
 
@@ -807,7 +814,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
             150000L, 10000L, 15L);
@@ -860,7 +867,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.getListChallenge(newUser, "pending");
         CommonResponse result1 = challengeController.getListChallenge(newUser, "accept");
@@ -896,7 +903,7 @@ public class ChallengeControllerTest {
         ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
@@ -914,7 +921,7 @@ public class ChallengeControllerTest {
         //when
         ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
             mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository);
+            mockProgressRepository, mockFmailyUserRepository);
         ChallengeController challengeController = new ChallengeController(challengeService);
         CommonResponse result = challengeController.getListChallenge(newUser, "pending");
 


### PR DESCRIPTION
## 📝 PR Summary

* 자녀 돈길 조회 API 입니다.  
   * 기존 노션에 있던 방식이 아닌 부모의 토큰에서 유저 정보를 뽑아서 해당 유저 아이디가 있는 familyUser 테이블을 참조해 자녀 모두의 리스트를 가져오는 방식으로 만들었습니다. (자녀 개인의 돈길 조회 리스트 방식과 통일하기 위해)

* 자녀 요청 수락/거절 API 입니다.
   * challengeId를 Pathvariable로 받고 request body에 수락 / 거절 여부와 상황에 따라 부모 코멘트까지 스트링으로 받습니다.
   * 특이사항으로는 돈길의 status 정보가 1이 아니라면 이미 처리된 돈길로 간주하고 400 에러를 띄웁니다.
#### 🌲 Working Branch

* feature/challengeRequest

### Related Issues

#28 