### PR TITLE
refactor: 돈길 생성 뷰 확정에 따른 Validation 추가 및 계약 대상 추가

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/request/ChallengeRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/ChallengeRequest.java
@@ -1,12 +1,16 @@
 package com.ceos.bankids.controller.request;
 
 import io.swagger.annotations.ApiModelProperty;
-import lombok.*;
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -15,6 +19,10 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @Builder
 public class ChallengeRequest {
+
+    @ApiModelProperty(example = "false")
+    @NotNull(message = "계약 대상의 성별은 필수값입니다.")
+    private Boolean isMom;
 
     @ApiModelProperty(example = "이자율 받기")
     @NotBlank(message = "돈길의 카테고리를 입력해주세요")
@@ -34,7 +42,10 @@ public class ChallengeRequest {
 
     @ApiModelProperty(example = "150000")
     @NotNull(message = "돈길의 목표 금액을 입력해주세요")
+    @Min(value = 1500, message = "목표 금액이 너무 적습니다.")
+    @Max(value = 500000, message = "목표 금액이 너무 높습니다.")
     private Long totalPrice;
+
 
     @ApiModelProperty(example = "3000")
     @NotNull(message = "돈길의 주당 금액을 입력해주세요")

--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -69,13 +69,18 @@ public class Challenge extends AbstractTimestamp {
     @JoinColumn(name = "challengeCategoryId", nullable = false)
     private ChallengeCategory challengeCategory;
 
+    @JsonBackReference
+    @ManyToOne
+    @JoinColumn(name = "contractUserId", nullable = false)
+    private User contractUser;
+
     @JsonManagedReference
     @OneToMany(mappedBy = "challenge")
     private List<Progress> progressList;
 
     @JsonManagedReference
-    @OneToMany(mappedBy = "challenge")
-    private List<ChallengeUser> challengeUserList;
+    @OneToOne(mappedBy = "challenge")
+    private ChallengeUser challengeUSer;
 
     @JsonManagedReference
     @OneToOne(mappedBy = "challenge")
@@ -92,6 +97,7 @@ public class Challenge extends AbstractTimestamp {
         Long status,
         Long interestRate,
         ChallengeCategory challengeCategory,
+        User contractUser,
         TargetItem targetItem,
         Comment comment
     ) {
@@ -116,6 +122,9 @@ public class Challenge extends AbstractTimestamp {
         if (challengeCategory == null) {
             throw new BadRequestException("카테고리는 필수값입니다.");
         }
+        if (contractUser == null) {
+            throw new BadRequestException("계약 대상 유저는 필수값입니다.");
+        }
         if (targetItem == null) {
             throw new BadRequestException("목표 아이템은 필수값입니다.");
         }
@@ -129,6 +138,7 @@ public class Challenge extends AbstractTimestamp {
         this.status = status;
         this.interestRate = interestRate;
         this.challengeCategory = challengeCategory;
+        this.contractUser = contractUser;
         this.targetItem = targetItem;
         this.comment = comment;
     }

--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -80,7 +80,7 @@ public class Challenge extends AbstractTimestamp {
 
     @JsonManagedReference
     @OneToOne(mappedBy = "challenge")
-    private ChallengeUser challengeUSer;
+    private ChallengeUser challengeUser;
 
     @JsonManagedReference
     @OneToOne(mappedBy = "challenge")

--- a/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
+++ b/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
@@ -9,6 +9,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -37,7 +38,7 @@ public class ChallengeUser extends AbstractTimestamp {
     private User user;
 
     @JsonBackReference
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "challengeId", nullable = false)
     private Challenge challenge;
 

--- a/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
@@ -20,6 +20,9 @@ public class ChallengeDTO {
     @ApiModelProperty(example = "1")
     private Long id;
 
+    @ApiModelProperty(example = "true")
+    private Boolean isMom;
+
     @ApiModelProperty(example = "에어팟 사기")
     private String title;
 
@@ -52,6 +55,7 @@ public class ChallengeDTO {
 
     public ChallengeDTO(Challenge challenge) {
         this.id = challenge.getId();
+        this.isMom = challenge.getContractUser().getIsFemale();
         this.title = challenge.getTitle();
         this.isAchieved = challenge.getIsAchieved();
         this.interestRate = challenge.getInterestRate();

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -51,7 +51,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         Boolean isMom = challengeRequest.getIsMom();
         FamilyUser familyUser = familyUserRepository.findByUserId(user.getId())
-            .orElseThrow(ForbiddenException::new);
+            .orElseThrow(() -> new ForbiddenException("가족이 없는 유저는 돈길을 생성 할 수 없습니다."));
         User contractUser = familyUserRepository.findByFamily(familyUser.getFamily())
             .stream()
             .filter(f -> !f.getUser().getIsKid() && f.getUser().getIsFemale() == isMom).findFirst()

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -56,11 +56,22 @@ public class ChallengeControllerTest {
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
         //given
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code1").provider("kakao").isKid(false).refreshToken("token1")
+            .build();
+
+        User newFather = User.builder().id(3L).username("parent2").isFemale(false)
+            .birthday("19990623")
+            .authenticationCode("code1").provider("kakao").isKid(false).refreshToken("token1")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -68,10 +79,28 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
+
+        Family newFamily = Family.builder().code("asdfasdf").build();
+
+        FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
+
+        FamilyUser newFamilyFather = FamilyUser.builder().user(newFather).family(newFamily).build();
+
+        FamilyUser newFamilyParent = FamilyUser.builder().user(newParent).family(newFamily).build();
+
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(newFamilyFather);
+        familyUserList.add(newFamilyParent);
+
+        Mockito.when(mockFmailyUserRepository.findByUserId(newUser.getId()))
+            .thenReturn(Optional.ofNullable(newFamilyUser));
+        Mockito.when(mockFmailyUserRepository.findByFamily(newFamily))
+            .thenReturn(familyUserList);
 
         Mockito.when(mockChallengeRepository.save(newChallenge)).thenReturn(newChallenge);
         Mockito.when(mockChallengeRepository.findById(1L))
@@ -116,11 +145,17 @@ public class ChallengeControllerTest {
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -128,11 +163,25 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
 
+        Family newFamily = Family.builder().code("asdfasdf").build();
+
+        FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
+
+        FamilyUser newFamilyParent = FamilyUser.builder().user(newParent).family(newFamily).build();
+
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(newFamilyParent);
+
+        Mockito.when(mockFmailyUserRepository.findByUserId(newUser.getId()))
+            .thenReturn(Optional.ofNullable(newFamilyUser));
+        Mockito.when(mockFmailyUserRepository.findByFamily(newFamily))
+            .thenReturn(familyUserList);
         ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
             .member("parent").user(newUser).build();
 
@@ -172,78 +221,6 @@ public class ChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("챌린지 생성 시, 챌린지에 걸리는 progress 정상 생성 테스트")
-    public void testMakeProgress() {
-
-        //given
-        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
-            ChallengeCategoryRepository.class);
-        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
-        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
-        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
-            ChallengeUserRepository.class);
-        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
-        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
-        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
-
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
-            5000L, 1000L, 5L);
-
-        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
-            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
-
-        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
-            .category("이자율 받기").build();
-
-        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
-
-        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
-            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
-            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
-            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
-            .interestRate(challengeRequest.getInterestRate()).build();
-
-        ChallengeUser newChallengeUser = ChallengeUser.builder().challenge(newChallenge)
-            .member("parent").user(newUser).build();
-
-        List<Progress> progressList = new ArrayList<>();
-        for (int i = 0; i < challengeRequest.getWeeks(); i++) {
-            Progress newProgress = Progress.builder().challenge(newChallenge).isAchieved(false)
-                .weeks(Long.valueOf(i)).build();
-            progressList.add(newProgress);
-        }
-
-        Mockito.when(mockChallengeRepository.save(newChallenge)).thenReturn(newChallenge);
-        Mockito.when(mockChallengeRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(newChallenge));
-        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
-            .thenReturn(newTargetItem);
-        Mockito.when(
-                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
-            .thenReturn(newChallengeCategory);
-        Mockito.when(mockChallengeUserRepository.save(newChallengeUser))
-            .thenReturn(newChallengeUser);
-        Mockito.when(mockChallengeUserRepository.findByChallengeId(newChallenge.getId()))
-            .thenReturn(Optional.ofNullable(newChallengeUser));
-        Mockito.when(mockProgressRepository.findByChallengeId(newChallenge.getId()))
-            .thenReturn(progressList);
-
-        //when
-        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
-            mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
-        ChallengeController challengeController = new ChallengeController(challengeService);
-        CommonResponse result = challengeController.postChallenge(newUser, challengeRequest,
-            mockBindingResult);
-
-        //then
-        ChallengeDTO challengeDTO = new ChallengeDTO(newChallenge);
-
-        Assertions.assertEquals(CommonResponse.onSuccess(challengeDTO), result);
-    }
-
-    @Test
     @DisplayName("챌린지 생성 시, 목표 아이템 입력 400 에러 테스트")
     public void testIfMakeChallengeTargetItemBadRequestErr() {
 
@@ -259,11 +236,17 @@ public class ChallengeControllerTest {
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "선물", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "선물", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -271,10 +254,24 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
+        Family newFamily = Family.builder().code("asdfasdf").build();
+
+        FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
+
+        FamilyUser newFamilyParent = FamilyUser.builder().user(newParent).family(newFamily).build();
+
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(newFamilyParent);
+
+        Mockito.when(mockFmailyUserRepository.findByUserId(newUser.getId()))
+            .thenReturn(Optional.ofNullable(newFamilyUser));
+        Mockito.when(mockFmailyUserRepository.findByFamily(newFamily))
+            .thenReturn(familyUserList);
         Mockito.when(mockChallengeCategoryRepository.findByCategory(
             newChallenge.getChallengeCategory().getCategory())).thenReturn(newChallengeCategory);
         Mockito.when(mockTargetItemRepository.findByName(newChallenge.getTargetItem().getName()))
@@ -308,11 +305,17 @@ public class ChallengeControllerTest {
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("형제와 경쟁 하기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "형제와 경쟁 하기", "전자제품",
+            "에어팟 사기", 30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -320,10 +323,25 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
+
+        Family newFamily = Family.builder().code("asdfasdf").build();
+
+        FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
+
+        FamilyUser newFamilyParent = FamilyUser.builder().user(newParent).family(newFamily).build();
+
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(newFamilyParent);
+
+        Mockito.when(mockFmailyUserRepository.findByUserId(newUser.getId()))
+            .thenReturn(Optional.ofNullable(newFamilyUser));
+        Mockito.when(mockFmailyUserRepository.findByFamily(newFamily))
+            .thenReturn(familyUserList);
 
         Mockito.when(mockChallengeCategoryRepository.findByCategory(
             newChallenge.getChallengeCategory().getCategory())).thenReturn(newChallengeCategory);
@@ -344,7 +362,7 @@ public class ChallengeControllerTest {
     }
 
     @Test
-    @DisplayName("챌린지 생성 시, 400 에러 테스트")
+    @DisplayName("챌린지 생성 시, 주차 400 에러 테스트")
     public void testIfMakeChallengeBadRequestErr() {
 
         //given
@@ -359,11 +377,17 @@ public class ChallengeControllerTest {
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
         BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 11L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -371,10 +395,157 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
+
+        Family newFamily = Family.builder().code("asdfasdf").build();
+
+        FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
+
+        FamilyUser newFamilyParent = FamilyUser.builder().user(newParent).family(newFamily).build();
+
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(newFamilyParent);
+
+        Mockito.when(mockFmailyUserRepository.findByUserId(newUser.getId()))
+            .thenReturn(Optional.ofNullable(newFamilyUser));
+        Mockito.when(mockFmailyUserRepository.findByFamily(newFamily))
+            .thenReturn(familyUserList);
+
+        Mockito.when(mockChallengeCategoryRepository.findByCategory(
+            newChallenge.getChallengeCategory().getCategory())).thenReturn(newChallengeCategory);
+        Mockito.when(mockTargetItemRepository.findByName(newChallenge.getTargetItem().getName()))
+            .thenReturn(newTargetItem);
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
+            mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
+        ChallengeController challengeController = new ChallengeController(challengeService);
+
+        //then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            challengeController.postChallenge(newUser, challengeRequest, mockBindingResult);
+        });
+
+    }
+
+    @Test
+    @DisplayName("챌린지 생성 시, 가족 없음 403에러 테스트")
+    public void testIfMakeChallengeNotExistFamilyForbiddenErr() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
+            150000L, 10000L, 15L);
+
+        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
+            .category("이자율 받기").build();
+
+        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
+
+        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        Mockito.when(mockChallengeCategoryRepository.findByCategory(
+            newChallenge.getChallengeCategory().getCategory())).thenReturn(newChallengeCategory);
+        Mockito.when(mockTargetItemRepository.findByName(newChallenge.getTargetItem().getName()))
+            .thenReturn(newTargetItem);
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
+            mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
+        ChallengeController challengeController = new ChallengeController(challengeService);
+
+        //then
+        Assertions.assertThrows(ForbiddenException.class, () -> {
+            challengeController.postChallenge(newUser, challengeRequest, mockBindingResult);
+        });
+
+    }
+
+    @Test
+    @DisplayName("챌린지 생성 시, 부모 없음 400에러 테스트")
+    public void testIfMakeChallengeNotExistParentBadRequestErr() {
+
+        //given
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
+            150000L, 10000L, 15L);
+
+        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
+            .category("이자율 받기").build();
+
+        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
+
+        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        Family newFamily = Family.builder().code("asdfasdf").build();
+
+        Family newFamily1 = Family.builder().code("asdfasdfadsf").build();
+
+        FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
+
+        FamilyUser newFamilyParent = FamilyUser.builder().user(newParent).family(newFamily1)
+            .build();
+
+        List<FamilyUser> familyUserList = new ArrayList<>();
+
+        Mockito.when(mockFmailyUserRepository.findByUserId(newUser.getId()))
+            .thenReturn(Optional.ofNullable(newFamilyUser));
+        Mockito.when(mockFmailyUserRepository.findByFamily(newFamily))
+            .thenReturn(familyUserList);
 
         Mockito.when(mockChallengeCategoryRepository.findByCategory(
             newChallenge.getChallengeCategory().getCategory())).thenReturn(newChallengeCategory);
@@ -409,11 +580,17 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -421,6 +598,7 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -477,11 +655,17 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser1 = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         User newUser2 = User.builder().id(2L).username("user2").isFemale(true).birthday("19990623")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
@@ -492,6 +676,7 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -533,11 +718,17 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser1 = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -545,6 +736,7 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -590,11 +782,17 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -602,6 +800,7 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -663,7 +862,8 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser1 = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
@@ -672,12 +872,18 @@ public class ChallengeControllerTest {
         User newUser2 = User.builder().id(2L).username("user2").isFemale(true).birthday("19990623")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
 
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
+
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
 
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -719,11 +925,17 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser1 = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -731,6 +943,7 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -779,11 +992,17 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser1 = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -791,6 +1010,7 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -836,14 +1056,21 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
-        ChallengeRequest challengeRequest1 = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 펜슬 사기",
+        ChallengeRequest challengeRequest1 = new ChallengeRequest(true, "이자율 받기", "전자제품",
+            "에어팟 펜슬 사기",
             10L, 100000L, 10000L, 10L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -851,12 +1078,14 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
 
         Challenge newChallenge1 = Challenge.builder().title(challengeRequest1.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest1.getTotalPrice())
             .weekPrice(challengeRequest1.getWeekPrice()).weeks(challengeRequest1.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
@@ -972,10 +1201,12 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
-        ChallengeRequest challengeRequest1 = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest1 = new ChallengeRequest(true, "이자율 받기", "전자제품", "아이팟 사기",
+            30L,
             1500L, 100L, 15L);
 
         User newUser = User.builder().id(1L).username("user").isFemale(true).birthday("19990521")
@@ -991,12 +1222,14 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().id(1L).title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
 
         Challenge newChallenge1 = Challenge.builder().id(2L).title(challengeRequest1.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest1.getTotalPrice())
             .weekPrice(challengeRequest1.getWeekPrice()).weeks(challengeRequest1.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
@@ -1075,10 +1308,12 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
-        ChallengeRequest challengeRequest1 = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest1 = new ChallengeRequest(true, "이자율 받기", "전자제품", "아이팟 사기",
+            30L,
             1500L, 100L, 15L);
 
         KidChallengeRequest successKidChallengeRequest = new KidChallengeRequest(true, null);
@@ -1097,12 +1332,14 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().id(1L).title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
 
         Challenge newChallenge1 = Challenge.builder().id(2L).title(challengeRequest1.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest1.getTotalPrice())
             .weekPrice(challengeRequest1.getWeekPrice()).weeks(challengeRequest1.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -1189,10 +1426,12 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
-        ChallengeRequest challengeRequest1 = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest1 = new ChallengeRequest(true, "이자율 받기", "전자제품", "아이팟 사기",
+            30L,
             1500L, 100L, 15L);
 
         KidChallengeRequest kidChallengeRequest = new KidChallengeRequest(true, null);
@@ -1210,12 +1449,14 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().id(1L).title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
 
         Challenge newChallenge1 = Challenge.builder().id(2L).title(challengeRequest1.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest1.getTotalPrice())
             .weekPrice(challengeRequest1.getWeekPrice()).weeks(challengeRequest1.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -1290,10 +1531,12 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
-        ChallengeRequest challengeRequest1 = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest1 = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             1500L, 100L, 15L);
 
         KidChallengeRequest kidChallengeRequest = new KidChallengeRequest(true, null);
@@ -1311,12 +1554,14 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().id(1L).title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
             .interestRate(challengeRequest.getInterestRate()).build();
 
         Challenge newChallenge1 = Challenge.builder().id(2L).title(challengeRequest1.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest1.getTotalPrice())
             .weekPrice(challengeRequest1.getWeekPrice()).weeks(challengeRequest1.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -1391,10 +1636,12 @@ public class ChallengeControllerTest {
         FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
         CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
-        ChallengeRequest challengeRequest1 = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest1 = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             1500L, 100L, 15L);
 
         KidChallengeRequest kidChallengeRequest = new KidChallengeRequest(true, null);
@@ -1412,12 +1659,14 @@ public class ChallengeControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().id(1L).title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
             .interestRate(challengeRequest.getInterestRate()).build();
 
         Challenge newChallenge1 = Challenge.builder().id(2L).title(challengeRequest1.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest1.getTotalPrice())
             .weekPrice(challengeRequest1.getWeekPrice()).weeks(challengeRequest1.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)

--- a/src/test/java/com/ceos/bankids/unit/controller/ProgressControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ProgressControllerTest.java
@@ -41,11 +41,17 @@ public class ProgressControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -53,6 +59,7 @@ public class ProgressControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -118,7 +125,8 @@ public class ProgressControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
@@ -128,12 +136,18 @@ public class ProgressControllerTest {
             .authenticationCode("code1").provider("kakao").isKid(true).refreshToken("token1")
             .build();
 
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
+
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
 
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
@@ -189,11 +203,17 @@ public class ProgressControllerTest {
             ChallengeUserRepository.class);
         ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
 
-        ChallengeRequest challengeRequest = new ChallengeRequest("이자율 받기", "전자제품", "에어팟 사기", 30L,
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
             150000L, 10000L, 15L);
 
         User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
             .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(false).refreshToken("token")
+            .build();
 
         ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
             .category("이자율 받기").build();
@@ -201,6 +221,7 @@ public class ProgressControllerTest {
         TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
 
         Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
             .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
             .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)


### PR DESCRIPTION
## 📝 PR Summary

* 계약 대상에 대한 컬럼을 추가했습니다.
   * challengeRequest에 isMom 정보를 bool 값으로 받습니다. 
   * isMom 정보에 따라 아빠 엄마 여부를 결정합니다.
   * 만약 해당 정보에 따른 값이 존재하지 않는다면 400 에러를 반환합니다.
   * 가족이 아예 없는 (FamilyUser 테이블에 row가 없다면) 403 에러를 반환합니다.
* 삭제 관련 수정은 삭제 확정 뷰와 User쪽에서 삭제  관련 timestamp 컬럼이 필요하기에 보류 했습니당
* 테스트 코드 커밋 따로 하려 했는데 ` git commit --amend ` 하다가 갑자기 통합 커밋 되버려서 따로 못했습니다...ㅜ
#### 🌲 Working Branch

* refactor/makeChallenge

### Related Issues

#34 
