### PR TITLE
feature: 돈길 생성 개수 제한 Validation 추가 및 돈길 걷기 시 savings update 추가

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/request/ChallengeRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/ChallengeRequest.java
@@ -11,6 +11,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
@@ -34,6 +35,7 @@ public class ChallengeRequest {
 
     @ApiModelProperty(example = "에어팟 사기")
     @NotBlank(message = "돈길의 제목을 입력해주세요")
+    @Length(min = 3, max = 15, message = "돈길 제목 길이를 확인해주세요")
     private String title;
 
     @ApiModelProperty(example = "30")
@@ -47,7 +49,7 @@ public class ChallengeRequest {
     private Long totalPrice;
 
 
-    @ApiModelProperty(example = "3000")
+    @ApiModelProperty(example = "10000")
     @NotNull(message = "돈길의 주당 금액을 입력해주세요")
     private Long weekPrice;
 

--- a/src/main/java/com/ceos/bankids/domain/Kid.java
+++ b/src/main/java/com/ceos/bankids/domain/Kid.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
@@ -24,6 +25,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Table(name = "Kid")
 @NoArgsConstructor
 @DynamicUpdate
+@DynamicInsert
 @EqualsAndHashCode(of = "id")
 public class Kid extends AbstractTimestamp {
 

--- a/src/main/java/com/ceos/bankids/domain/Parent.java
+++ b/src/main/java/com/ceos/bankids/domain/Parent.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
@@ -24,6 +25,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Table(name = "Parent")
 @NoArgsConstructor
 @DynamicUpdate
+@DynamicInsert
 @EqualsAndHashCode(of = "id")
 public class Parent extends AbstractTimestamp {
 

--- a/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ChallengeDTO.java
@@ -25,9 +25,11 @@ public class ChallengeDTO {
     @ApiModelProperty(example = "에어팟 사기")
     private String title;
 
-    private String targetItemName;
+    @ApiModelProperty(example = "전자제품")
+    private String itemName;
 
-    private String challengeCategoryName;
+    @ApiModelProperty(example = "부모와 함께 하기")
+    private String challengeCategory;
 
     @ApiModelProperty(example = "false")
     private Boolean isAchieved;
@@ -60,8 +62,8 @@ public class ChallengeDTO {
         this.id = challenge.getId();
         this.isMom = challenge.getContractUser().getIsFemale();
         this.title = challenge.getTitle();
-        this.targetItemName = challenge.getTargetItem().getName();
-        this.challengeCategoryName = challenge.getChallengeCategory().getCategory();
+        this.itemName = challenge.getTargetItem().getName();
+        this.challengeCategory = challenge.getChallengeCategory().getCategory();
         this.isAchieved = challenge.getIsAchieved();
         this.interestRate = challenge.getInterestRate();
         this.totalPrice = challenge.getTotalPrice();

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -57,7 +57,8 @@ public class ChallengeServiceImpl implements ChallengeService {
     public ChallengeDTO createChallenge(User user, ChallengeRequest challengeRequest) {
 
         long count = challengeUserRepository.findByUserId(user.getId()).stream()
-            .filter(challengeUser -> challengeUser.getChallenge().getStatus() == 2).count();
+            .filter(challengeUser -> challengeUser.getChallenge().getStatus() == 2
+                && !challengeUser.getChallenge().getIsAchieved()).count();
         if (count >= 5) {
             throw new ForbiddenException("돈길 생성 개수 제한에 도달했습니다.");
         }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -56,6 +56,11 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Override
     public ChallengeDTO createChallenge(User user, ChallengeRequest challengeRequest) {
 
+        long count = challengeUserRepository.findByUserId(user.getId()).stream()
+            .filter(challengeUser -> challengeUser.getChallenge().getStatus() == 2).count();
+        if (count >= 5) {
+            throw new ForbiddenException("돈길 생성 개수 제한에 도달했습니다.");
+        }
         Boolean isMom = challengeRequest.getIsMom();
         FamilyUser familyUser = familyUserRepository.findByUserId(user.getId())
             .orElseThrow(() -> new ForbiddenException("가족이 없는 유저는 돈길을 생성 할 수 없습니다."));

--- a/src/main/java/com/ceos/bankids/service/ProgressServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ProgressServiceImpl.java
@@ -1,18 +1,24 @@
 package com.ceos.bankids.service;
 
 import com.ceos.bankids.controller.request.ProgressRequest;
+import com.ceos.bankids.domain.Challenge;
 import com.ceos.bankids.domain.ChallengeUser;
+import com.ceos.bankids.domain.Family;
+import com.ceos.bankids.domain.FamilyUser;
 import com.ceos.bankids.domain.Progress;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.ProgressDTO;
 import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.exception.ForbiddenException;
+import com.ceos.bankids.repository.ChallengeRepository;
 import com.ceos.bankids.repository.ChallengeUserRepository;
+import com.ceos.bankids.repository.FamilyUserRepository;
 import com.ceos.bankids.repository.ProgressRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -21,7 +27,10 @@ public class ProgressServiceImpl implements ProgressService {
 
     private final ProgressRepository progressRepository;
     private final ChallengeUserRepository challengeUserRepository;
+    private final ChallengeRepository challengeRepository;
+    private final FamilyUserRepository familyUserRepository;
 
+    @Transactional
     @Override
     public ProgressDTO updateProgress(User user, Long challengeId,
         ProgressRequest progressRequest) {
@@ -38,6 +47,24 @@ public class ProgressServiceImpl implements ProgressService {
         });
         if (progress.isPresent()) {
             progress.ifPresent(p -> {
+                FamilyUser familyUser = familyUserRepository.findByUserId(user.getId())
+                    .orElseThrow(BadRequestException::new);
+                Family family = familyUser.getFamily();
+                familyUserRepository.findByFamily(family).forEach(familyUser1 -> {
+                    if (familyUser1.getUser() == user) {
+                        Long savings = familyUser1.getUser().getKid().getSavings();
+                        Challenge challenge = challengeRepository.findById(challengeId)
+                            .orElseThrow(BadRequestException::new);
+                        Long weekPrice = challenge.getWeekPrice();
+                        familyUser1.getUser().getKid().setSavings(savings + weekPrice);
+                    } else if (!familyUser1.getUser().getIsKid()) {
+                        Long savings = familyUser1.getUser().getParent().getSavings();
+                        Challenge challenge = challengeRepository.findById(challengeId)
+                            .orElseThrow(BadRequestException::new);
+                        Long weekPrice = challenge.getWeekPrice();
+                        familyUser1.getUser().getParent().setSavings(savings + weekPrice);
+                    }
+                });
                 p.setIsAchieved(true);
                 progressRepository.save(p);
             });

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -136,6 +136,143 @@ public class ChallengeControllerTest {
     }
 
     @Test
+    @DisplayName("챌린지 생성 개수 제한 도달 시, 403 에러 테스트")
+    public void testIfPostChallengeMaxCountForbiddenErr() {
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+            ChallengeCategoryRepository.class);
+        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+            ChallengeUserRepository.class);
+        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+        FamilyUserRepository mockFmailyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
+        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+        //given
+        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+            30L,
+            150000L, 10000L, 15L);
+
+        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
+            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+
+        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+            .birthday("19990623")
+            .authenticationCode("code1").provider("kakao").isKid(false).refreshToken("token1")
+            .build();
+
+        User newFather = User.builder().id(3L).username("parent2").isFemale(false)
+            .birthday("19990623")
+            .authenticationCode("code1").provider("kakao").isKid(false).refreshToken("token1")
+            .build();
+
+        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
+            .category("이자율 받기").build();
+
+        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
+
+        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        Challenge newChallenge5 = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        Challenge newChallenge1 = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        Challenge newChallenge2 = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        Challenge newChallenge3 = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        Challenge newChallenge4 = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(false).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
+        Family newFamily = Family.builder().code("asdfasdf").build();
+
+        FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
+
+        FamilyUser newFamilyFather = FamilyUser.builder().user(newFather).family(newFamily).build();
+
+        FamilyUser newFamilyParent = FamilyUser.builder().user(newParent).family(newFamily).build();
+
+        ChallengeUser newChallengeUser1 = ChallengeUser.builder().user(newUser)
+            .challenge(newChallenge1).member("parent").build();
+
+        ChallengeUser newChallengeUser2 = ChallengeUser.builder().user(newUser)
+            .challenge(newChallenge2).member("parent").build();
+
+        ChallengeUser newChallengeUser3 = ChallengeUser.builder().user(newUser)
+            .challenge(newChallenge3).member("parent").build();
+
+        ChallengeUser newChallengeUser4 = ChallengeUser.builder().user(newUser)
+            .challenge(newChallenge4).member("parent").build();
+
+        ChallengeUser newChallengeUser5 = ChallengeUser.builder().user(newUser)
+            .challenge(newChallenge5).member("parent").build();
+
+        List<ChallengeUser> challengeUserList = List.of(newChallengeUser1, newChallengeUser2,
+            newChallengeUser3, newChallengeUser4, newChallengeUser5);
+
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(newFamilyFather);
+        familyUserList.add(newFamilyParent);
+
+        Mockito.when(mockFmailyUserRepository.findByUserId(newUser.getId()))
+            .thenReturn(Optional.ofNullable(newFamilyUser));
+        Mockito.when(mockFmailyUserRepository.findByFamily(newFamily))
+            .thenReturn(familyUserList);
+        Mockito.when(mockChallengeUserRepository.findByUserId(newUser.getId()))
+            .thenReturn(challengeUserList);
+
+        Mockito.when(mockChallengeRepository.save(newChallenge)).thenReturn(newChallenge);
+        Mockito.when(mockChallengeRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(newChallenge));
+        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
+            .thenReturn(newTargetItem);
+        Mockito.when(
+                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
+            .thenReturn(newChallengeCategory);
+
+        //when
+        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
+            mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
+            mockProgressRepository, mockFmailyUserRepository, mockCommentRepository);
+        ChallengeController challengeController = new ChallengeController(challengeService);
+
+        //then
+        Assertions.assertThrows(ForbiddenException.class,
+            () -> challengeController.postChallenge(newUser, challengeRequest, mockBindingResult));
+    }
+
+    @Test
     @DisplayName("챌린지 생성 시, 챌린지-유저 미들 테이블 로우 정상 생성 확인")
     public void testMakeChallengeUserRow() {
 


### PR DESCRIPTION
## 📝 PR Summary

* 돈길 생성 개수 제한 Validation 추가
   * status가 2(accept)이고 isAchieved가 false인 돈길 개수가 5 이상이면 403에러
* 돈길 걷기 시 Kid / Parent savings 컬럼 값을 돈길의 weekPrice를 더해주고 update
#### 🌲 Working Branch

* feature/updateSavings

### Related Issues

#44 