### PR TITLE
feat: 유저 정보 조회 API 및 자잘한 수정

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -41,12 +41,13 @@ public class UserController {
     }
 
     @ApiOperation(value = "토큰 리프레시")
-    @GetMapping(value = "/refresh", produces = "application/json; charset=utf-8")
+    @PatchMapping(value = "/refresh", produces = "application/json; charset=utf-8")
     @ResponseBody
-    public CommonResponse<LoginDTO> refreshUserToken(@AuthenticationPrincipal User authUser,
+    public CommonResponse<LoginDTO> refreshUserToken(
         @CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
 
-        LoginDTO loginDTO = userService.issueNewTokens(authUser, true, response);
+        User user = userService.getUserByRefreshToken(refreshToken);
+        LoginDTO loginDTO = userService.issueNewTokens(user, response);
 
         return CommonResponse.onSuccess(loginDTO);
     }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -4,6 +4,7 @@ import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.MyPageDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
@@ -48,6 +49,16 @@ public class UserController {
         LoginDTO loginDTO = userService.issueNewTokens(authUser, true, response);
 
         return CommonResponse.onSuccess(loginDTO);
+    }
+
+    @ApiOperation(value = "유저 정보 조회하기")
+    @GetMapping(value = "", produces = "application/json; charset=utf-8")
+    @ResponseBody
+    public CommonResponse<MyPageDTO> getUserInfo(@AuthenticationPrincipal User authUser) {
+
+        MyPageDTO myPageDTO = userService.getUserInformation(authUser);
+
+        return CommonResponse.onSuccess(myPageDTO);
     }
 
 }

--- a/src/main/java/com/ceos/bankids/domain/Kid.java
+++ b/src/main/java/com/ceos/bankids/domain/Kid.java
@@ -33,19 +33,19 @@ public class Kid extends AbstractTimestamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Long savings;
 
-    @Column(nullable = false, length = 5)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Long achievedChallenge;
 
-    @Column(nullable = false, length = 5)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Long totalChallenge;
 
-    @Column(nullable = false, length = 5)
+    @Column(nullable = false)
     @ColumnDefault("1")
     private Long level;
 

--- a/src/main/java/com/ceos/bankids/domain/Kid.java
+++ b/src/main/java/com/ceos/bankids/domain/Kid.java
@@ -36,6 +36,14 @@ public class Kid extends AbstractTimestamp {
     private Long savings;
 
     @Column(nullable = false, length = 5)
+    @ColumnDefault("0")
+    private Long achievedChallenge;
+
+    @Column(nullable = false, length = 5)
+    @ColumnDefault("0")
+    private Long totalChallenge;
+
+    @Column(nullable = false, length = 5)
     @ColumnDefault("1")
     private Long level;
 
@@ -47,6 +55,8 @@ public class Kid extends AbstractTimestamp {
     public Kid(
         Long id,
         Long savings,
+        Long achievedChallenge,
+        Long totalChallenge,
         Long level,
         User user
     ) {
@@ -58,6 +68,8 @@ public class Kid extends AbstractTimestamp {
         }
         this.id = id;
         this.savings = savings;
+        this.achievedChallenge = achievedChallenge;
+        this.totalChallenge = totalChallenge;
         this.level = level;
         this.user = user;
     }

--- a/src/main/java/com/ceos/bankids/domain/Parent.java
+++ b/src/main/java/com/ceos/bankids/domain/Parent.java
@@ -33,19 +33,19 @@ public class Parent extends AbstractTimestamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 5)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Long totalChallenge;
 
-    @Column(nullable = false, length = 5)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Long acceptedRequest;
 
-    @Column(nullable = false, length = 5)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Long totalRequest;
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Long savings;
 

--- a/src/main/java/com/ceos/bankids/domain/Parent.java
+++ b/src/main/java/com/ceos/bankids/domain/Parent.java
@@ -31,6 +31,18 @@ public class Parent extends AbstractTimestamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 5)
+    @ColumnDefault("0")
+    private Long totalChallenge;
+
+    @Column(nullable = false, length = 5)
+    @ColumnDefault("0")
+    private Long acceptedRequest;
+
+    @Column(nullable = false, length = 5)
+    @ColumnDefault("0")
+    private Long totalRequest;
+
     @Column(nullable = false, length = 10)
     @ColumnDefault("0")
     private Long savings;
@@ -42,6 +54,9 @@ public class Parent extends AbstractTimestamp {
     @Builder
     public Parent(
         Long id,
+        Long totalChallenge,
+        Long acceptedRequest,
+        Long totalRequest,
         Long savings,
         User user
     ) {
@@ -49,6 +64,9 @@ public class Parent extends AbstractTimestamp {
             throw new BadRequestException("유저는 필수값입니다.");
         }
         this.id = id;
+        this.totalChallenge = totalChallenge;
+        this.acceptedRequest = acceptedRequest;
+        this.totalRequest = totalRequest;
         this.savings = savings;
         this.user = user;
     }

--- a/src/main/java/com/ceos/bankids/dto/KidDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidDTO.java
@@ -1,0 +1,24 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.Kid;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class KidDTO {
+
+    @ApiModelProperty(example = "8")
+    Long achievedChallenge;
+    @ApiModelProperty(example = "10")
+    Long totalChallenge;
+    @ApiModelProperty(example = "1")
+    Long level;
+
+    public KidDTO(Kid kid) {
+        this.level = kid.getLevel();
+    }
+}

--- a/src/main/java/com/ceos/bankids/dto/KidDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidDTO.java
@@ -19,6 +19,8 @@ public class KidDTO {
     Long level;
 
     public KidDTO(Kid kid) {
+        this.achievedChallenge = kid.getAchievedChallenge();
+        this.totalChallenge = kid.getTotalChallenge();
         this.level = kid.getLevel();
     }
 }

--- a/src/main/java/com/ceos/bankids/dto/LoginDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/LoginDTO.java
@@ -11,14 +11,11 @@ import lombok.ToString;
 public class LoginDTO {
 
     @ApiModelProperty(example = "true")
-    private Boolean isRegistered;
-    @ApiModelProperty(example = "true")
     private Boolean isKid;
     @ApiModelProperty(example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ~~~~")
     private String accessToken;
 
-    public LoginDTO(Boolean isRegistered, Boolean isKid, String accessToken) {
-        this.isRegistered = isRegistered;
+    public LoginDTO(Boolean isKid, String accessToken) {
         this.isKid = isKid;
         this.accessToken = accessToken;
     }

--- a/src/main/java/com/ceos/bankids/dto/MyPageDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/MyPageDTO.java
@@ -1,8 +1,5 @@
 package com.ceos.bankids.dto;
 
-import com.ceos.bankids.domain.Kid;
-import com.ceos.bankids.domain.Parent;
-import com.ceos.bankids.domain.User;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -13,37 +10,20 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class MyPageDTO {
 
-    @ApiModelProperty(example = "주어랑")
-    String username;
-    @ApiModelProperty(example = "true")
-    Boolean isFemale;
-    @ApiModelProperty(example = "true")
-    Boolean isKid;
-    @ApiModelProperty(example = "19990521")
-    String birthday;
-    @ApiModelProperty(example = "01019990521")
-    String phone;
-    @ApiModelProperty(example = "0")
-    Long savings;
-    @ApiModelProperty(example = "1")
-    Long level;
+    @ApiModelProperty(example = "UserDTO")
+    UserDTO userDTO;
+    @ApiModelProperty(example = "KidDTO")
+    KidDTO kidDTO;
+    @ApiModelProperty(example = "ParentDTO")
+    ParentDTO parentDTO;
 
-    public MyPageDTO(User user, Kid kid) {
-        this.username = user.getUsername();
-        this.isFemale = user.getIsFemale();
-        this.isKid = user.getIsKid();
-        this.birthday = user.getBirthday();
-        this.phone = user.getPhone();
-        this.savings = kid.getSavings();
-        this.level = kid.getLevel();
+    public MyPageDTO(UserDTO userDTO, KidDTO kidDTO) {
+        this.userDTO = userDTO;
+        this.kidDTO = kidDTO;
     }
 
-    public MyPageDTO(User user, Parent parent) {
-        this.username = user.getUsername();
-        this.isFemale = user.getIsFemale();
-        this.isKid = user.getIsKid();
-        this.birthday = user.getBirthday();
-        this.phone = user.getPhone();
-        this.savings = parent.getSavings();
+    public MyPageDTO(UserDTO userDTO, ParentDTO parentDTO) {
+        this.userDTO = userDTO;
+        this.parentDTO = parentDTO;
     }
 }

--- a/src/main/java/com/ceos/bankids/dto/MyPageDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/MyPageDTO.java
@@ -1,0 +1,49 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.Kid;
+import com.ceos.bankids.domain.Parent;
+import com.ceos.bankids.domain.User;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class MyPageDTO {
+
+    @ApiModelProperty(example = "주어랑")
+    String username;
+    @ApiModelProperty(example = "true")
+    Boolean isFemale;
+    @ApiModelProperty(example = "true")
+    Boolean isKid;
+    @ApiModelProperty(example = "19990521")
+    String birthday;
+    @ApiModelProperty(example = "01019990521")
+    String phone;
+    @ApiModelProperty(example = "0")
+    Long savings;
+    @ApiModelProperty(example = "1")
+    Long level;
+
+    public MyPageDTO(User user, Kid kid) {
+        this.username = user.getUsername();
+        this.isFemale = user.getIsFemale();
+        this.isKid = user.getIsKid();
+        this.birthday = user.getBirthday();
+        this.phone = user.getPhone();
+        this.savings = kid.getSavings();
+        this.level = kid.getLevel();
+    }
+
+    public MyPageDTO(User user, Parent parent) {
+        this.username = user.getUsername();
+        this.isFemale = user.getIsFemale();
+        this.isKid = user.getIsKid();
+        this.birthday = user.getBirthday();
+        this.phone = user.getPhone();
+        this.savings = parent.getSavings();
+    }
+}

--- a/src/main/java/com/ceos/bankids/dto/MyPageDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/MyPageDTO.java
@@ -11,19 +11,19 @@ import lombok.ToString;
 public class MyPageDTO {
 
     @ApiModelProperty(example = "UserDTO")
-    UserDTO userDTO;
+    UserDTO user;
     @ApiModelProperty(example = "KidDTO")
-    KidDTO kidDTO;
+    KidDTO kid;
     @ApiModelProperty(example = "ParentDTO")
-    ParentDTO parentDTO;
+    ParentDTO parent;
 
     public MyPageDTO(UserDTO userDTO, KidDTO kidDTO) {
-        this.userDTO = userDTO;
-        this.kidDTO = kidDTO;
+        this.user = userDTO;
+        this.kid = kidDTO;
     }
 
     public MyPageDTO(UserDTO userDTO, ParentDTO parentDTO) {
-        this.userDTO = userDTO;
-        this.parentDTO = parentDTO;
+        this.user = userDTO;
+        this.parent = parentDTO;
     }
 }

--- a/src/main/java/com/ceos/bankids/dto/ParentDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ParentDTO.java
@@ -21,6 +21,9 @@ public class ParentDTO {
     Long savings;
 
     public ParentDTO(Parent parent) {
+        this.totalChallenge = parent.getTotalChallenge();
+        this.acceptedRequest = parent.getAcceptedRequest();
+        this.totalRequest = parent.getTotalRequest();
         this.savings = parent.getSavings();
     }
 }

--- a/src/main/java/com/ceos/bankids/dto/ParentDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ParentDTO.java
@@ -1,0 +1,26 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.Parent;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class ParentDTO {
+
+    @ApiModelProperty(example = "15")
+    Long totalChallenge;
+    @ApiModelProperty(example = "8")
+    Long acceptedRequest;
+    @ApiModelProperty(example = "10")
+    Long totalRequest;
+    @ApiModelProperty(example = "300000")
+    Long savings;
+
+    public ParentDTO(Parent parent) {
+        this.savings = parent.getSavings();
+    }
+}

--- a/src/main/java/com/ceos/bankids/service/JwtTokenServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/JwtTokenServiceImpl.java
@@ -50,6 +50,7 @@ public class JwtTokenServiceImpl implements JwtTokenService {
         Date now = new Date();
         return Jwts.builder()
             .setIssuedAt(now)
+            .setSubject(id.toString())
             .setExpiration(new Date(now.getTime() + Duration.ofMinutes(20160).toMillis()))
             .claim("id", id)
             .claim("roles", "USER")

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -67,7 +67,7 @@ public class KakaoServiceImpl implements KakaoService {
         HttpServletResponse response) {
         Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
         if (user.isPresent()) {
-            LoginDTO loginDTO = userService.issueNewTokens(user.get(), true, response);
+            LoginDTO loginDTO = userService.issueNewTokens(user.get(), response);
 
             return loginDTO;
         } else {
@@ -78,8 +78,8 @@ public class KakaoServiceImpl implements KakaoService {
                 .build();
             uRepo.save(newUser);
 
-            LoginDTO loginDTO = userService.issueNewTokens(newUser, false, response);
-    
+            LoginDTO loginDTO = userService.issueNewTokens(newUser, response);
+
             return loginDTO;
         }
     }

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -79,7 +79,7 @@ public class KakaoServiceImpl implements KakaoService {
             uRepo.save(newUser);
 
             LoginDTO loginDTO = userService.issueNewTokens(newUser, false, response);
-
+    
             return loginDTO;
         }
     }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -3,6 +3,7 @@ package com.ceos.bankids.service;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.MyPageDTO;
 import com.ceos.bankids.dto.UserDTO;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -18,4 +19,6 @@ public interface UserService {
 
     public LoginDTO issueNewTokens(@AuthenticationPrincipal User authUser, Boolean isRegistered,
         HttpServletResponse response);
+
+    public MyPageDTO getUserInformation(User user);
 }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -17,8 +17,9 @@ public interface UserService {
     public UserDTO updateUserType(@AuthenticationPrincipal User authUser,
         @Valid @RequestBody UserTypeRequest userTypeRequest);
 
-    public LoginDTO issueNewTokens(@AuthenticationPrincipal User authUser, Boolean isRegistered,
-        HttpServletResponse response);
+    public LoginDTO issueNewTokens(User authUser, HttpServletResponse response);
 
     public MyPageDTO getUserInformation(User user);
+
+    public User getUserByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.ceos.bankids.domain.Kid;
 import com.ceos.bankids.domain.Parent;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.MyPageDTO;
 import com.ceos.bankids.dto.TokenDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.exception.BadRequestException;
@@ -87,5 +88,17 @@ public class UserServiceImpl implements UserService {
         LoginDTO loginDTO = new LoginDTO(isRegistered, user.getIsKid(),
             jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
         return loginDTO;
+    }
+
+    @Override
+    @Transactional
+    public MyPageDTO getUserInformation(User user) {
+        if (user.getIsKid()) {
+            MyPageDTO myPageDTO = new MyPageDTO(user, user.getKid());
+            return myPageDTO;
+        } else {
+            MyPageDTO myPageDTO = new MyPageDTO(user, user.getParent());
+            return myPageDTO;
+        }
     }
 }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -4,8 +4,10 @@ import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.Kid;
 import com.ceos.bankids.domain.Parent;
 import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.KidDTO;
 import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.MyPageDTO;
+import com.ceos.bankids.dto.ParentDTO;
 import com.ceos.bankids.dto.TokenDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.exception.BadRequestException;
@@ -98,21 +100,24 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public MyPageDTO getUserInformation(User user) {
-        if (user.getIsKid()) {
-            MyPageDTO myPageDTO = new MyPageDTO(user, user.getKid());
-            return myPageDTO;
-        } else {
-            MyPageDTO myPageDTO = new MyPageDTO(user, user.getParent());
-            return myPageDTO;
-        }
-    }
-
-    @Override
-    @Transactional
     public User getUserByRefreshToken(String refreshToken) {
         String userId = jwtTokenServiceImpl.getUserIdFromJwtToken(refreshToken);
         Optional<User> user = uRepo.findById(Long.parseLong(userId));
         return user.get();
+    }
+
+    @Override
+    @Transactional
+    public MyPageDTO getUserInformation(User user) {
+        MyPageDTO myPageDTO;
+        UserDTO userDTO = new UserDTO(user);
+        if (user.getIsKid()) {
+            KidDTO kidDTO = new KidDTO(user.getKid());
+            myPageDTO = new MyPageDTO(userDTO, kidDTO);
+        } else {
+            ParentDTO parentDTO = new ParentDTO(user.getParent());
+            myPageDTO = new MyPageDTO(userDTO, parentDTO);
+        }
+        return myPageDTO;
     }
 }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -75,8 +75,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public LoginDTO issueNewTokens(User user, Boolean isRegistered,
-        HttpServletResponse response) {
+    public LoginDTO issueNewTokens(User user, HttpServletResponse response) {
         String newRefreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(user.getId());
         user.setRefreshToken(newRefreshToken);
         uRepo.save(user);
@@ -107,5 +106,13 @@ public class UserServiceImpl implements UserService {
             MyPageDTO myPageDTO = new MyPageDTO(user, user.getParent());
             return myPageDTO;
         }
+    }
+
+    @Override
+    @Transactional
+    public User getUserByRefreshToken(String refreshToken) {
+        String userId = jwtTokenServiceImpl.getUserIdFromJwtToken(refreshToken);
+        Optional<User> user = uRepo.findById(Long.parseLong(userId));
+        return user.get();
     }
 }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -12,6 +12,7 @@ import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.repository.KidRepository;
 import com.ceos.bankids.repository.ParentRepository;
 import com.ceos.bankids.repository.UserRepository;
+import java.util.Calendar;
 import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
@@ -37,10 +38,16 @@ public class UserServiceImpl implements UserService {
         @Valid @RequestBody UserTypeRequest userTypeRequest) {
         Long userId = authUser.getId();
         Optional<User> user = uRepo.findById(userId);
+
+        Calendar cal = Calendar.getInstance();
+        Integer currYear = cal.get(Calendar.YEAR);
+        Integer birthYear = Integer.parseInt(userTypeRequest.getBirthday()) / 10000;
         if (user.isEmpty()) {
             throw new BadRequestException("존재하지 않는 유저입니다.");
         } else if (user.get().getIsFemale() != null) {
             throw new BadRequestException("이미 유저 타입을 선택한 유저입니다.");
+        } else if (birthYear > currYear || birthYear <= currYear - 100) {
+            throw new BadRequestException("유효하지 않은 생년월일입니다.");
         } else {
             user.get().setBirthday(userTypeRequest.getBirthday());
             user.get().setIsFemale(userTypeRequest.getIsFemale());

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -85,7 +85,7 @@ public class UserServiceImpl implements UserService {
 
         response.addCookie(cookie);
 
-        LoginDTO loginDTO = new LoginDTO(isRegistered, user.getIsKid(),
+        LoginDTO loginDTO = new LoginDTO(user.getIsKid(),
             jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
         return loginDTO;
     }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -59,12 +59,17 @@ public class UserServiceImpl implements UserService {
             if (user.get().getIsKid() == true) {
                 Kid newKid = Kid.builder()
                     .savings(0L)
-                    .user(user.get())
+                    .achievedChallenge(0L)
+                    .totalChallenge(0L)
                     .level(1L)
+                    .user(user.get())
                     .build();
                 kRepo.save(newKid);
             } else {
                 Parent newParent = Parent.builder()
+                    .totalChallenge(0L)
+                    .acceptedRequest(0L)
+                    .totalRequest(0L)
                     .savings(0L)
                     .user(user.get())
                     .build();

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -116,7 +116,9 @@ public class UserServiceImpl implements UserService {
     public MyPageDTO getUserInformation(User user) {
         MyPageDTO myPageDTO;
         UserDTO userDTO = new UserDTO(user);
-        if (user.getIsKid()) {
+        if (user.getIsKid() == null) {
+            throw new BadRequestException("유저 타입이 선택되지 않은 유저입니다.");
+        } else if (user.getIsKid() == true) {
             KidDTO kidDTO = new KidDTO(user.getKid());
             myPageDTO = new MyPageDTO(userDTO, kidDTO);
         } else {

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -175,6 +175,78 @@ public class UserControllerTest {
     }
 
     @Test
+    @DisplayName("100세 초과 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithTooEarlyBirthdayThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("18880818", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        UserController userController = new UserController(
+            userService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("0세 미만 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithTooLateBirthdayThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("23450818", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        UserController userController = new UserController(
+            userService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
     @DisplayName("자녀 지정시, 자녀 row 생성 확인")
     public void testIfKidInsertSucceedWhenUserTypePatchSucceed() {
         // given

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -6,7 +6,10 @@ import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.Kid;
 import com.ceos.bankids.domain.Parent;
 import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.KidDTO;
 import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.MyPageDTO;
+import com.ceos.bankids.dto.ParentDTO;
 import com.ceos.bankids.dto.TokenDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.exception.BadRequestException;
@@ -437,5 +440,145 @@ public class UserControllerTest {
         // then
         LoginDTO loginDTO = new LoginDTO(false, "aT");
         Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+    }
+
+    @Test
+    @DisplayName("부모 유저 정보 조회 성공 시, 부모 결과 반환하는지 확인")
+    public void testIfGetParentInfoSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+        Parent parent = Parent.builder()
+            .totalChallenge(0L)
+            .acceptedRequest(0L)
+            .totalRequest(0L)
+            .savings(0L)
+            .user(user)
+            .build();
+        user.setParent(parent);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        UserController userController = new UserController(
+            userService
+        );
+
+        CommonResponse result = userController.getUserInfo(user);
+
+        // then
+        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new ParentDTO(parent));
+        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
+    }
+
+    @Test
+    @DisplayName("자녀 유저 정보 조회 성공 시, 자녀 결과 반환하는지 확인")
+    public void testIfGetKidInfoSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        UserController userController = new UserController(
+            userService
+        );
+
+        CommonResponse result = userController.getUserInfo(user);
+
+        // then
+        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new KidDTO(kid));
+        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 타입 선택 없이 유저 정보 조회 시, 에러 처리하는지 확인")
+    public void testIfGetUserInfoFailWithoutUserTypeThenThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(null)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        UserController userController = new UserController(
+            userService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.getUserInfo(user);
+        });
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -362,7 +362,7 @@ public class UserControllerTest {
         CommonResponse result = userController.refreshUserToken(user, "rT", response);
 
         // then
-        LoginDTO loginDTO = new LoginDTO(true, false, "aT");
+        LoginDTO loginDTO = new LoginDTO(false, "aT");
         Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -409,7 +409,7 @@ public class UserControllerTest {
         UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(null));
+            .thenReturn(Optional.ofNullable(user));
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
 
@@ -417,6 +417,7 @@ public class UserControllerTest {
         TokenDTO tokenDTO = new TokenDTO(user);
         Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
         Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
 
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
 
@@ -431,7 +432,7 @@ public class UserControllerTest {
             userService
         );
 
-        CommonResponse result = userController.refreshUserToken(user, "rT", response);
+        CommonResponse result = userController.refreshUserToken("rT", response);
 
         // then
         LoginDTO loginDTO = new LoginDTO(false, "aT");


### PR DESCRIPTION
## 📝 PR Summary
- 토큰 리프레시 API 메소드 PATCH로 변경, 로직 변경 있습니다.
- 유저 생년월일 입력 validation 추가했습니다.
- LoginDTO에서 isKid로 분류하기로 프론트와 상의 후 결정되어 isRegistered 값 제거했습니다.
- 마이페이지 조회 유저 부모/자녀 여부에 따라 결과 값 다르지만 같은 DTO로 처리했습니다.
- **마이페이지에 들어가는 정보 확정됨에 따라 domain 추가 내용 있습니다...**
추가 내역만 있고 삭제는 없습니다!
챌린지 생성/수락/거절/성공입력 등의 시점에 고루고루 추가되어야 하는데, 직접 하셔도 되고 제가 해도 됩니다 대공사네요.
파이팅!
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/userInfo
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] 토큰으로 인증된 유저의 정보 반환
- [x] 유저 아이디 노출 없이 정보 반환
- [x] 부모/자녀 분리
- [x] 삭제(탈퇴) 유저일 경우 에러 처리 되는지 확인
- [x] 마이페이지에 필요 정보 가공
- [x] 테스트 코드
- [x] 유저 생년월일 입력 시 validation
- [x] 유저 로그인/리프레시 isRegistered 제거
- [x] 토큰 리프레시 로직/메소드 수정

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#41
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
