### PR TITLE
feat: 아이들 목록 조회 API

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/FamilyController.java
+++ b/src/main/java/com/ceos/bankids/controller/FamilyController.java
@@ -3,8 +3,11 @@ package com.ceos.bankids.controller;
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
+import com.ceos.bankids.dto.KidListDTO;
+import com.ceos.bankids.exception.ForbiddenException;
 import com.ceos.bankids.service.FamilyServiceImpl;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -40,5 +43,18 @@ public class FamilyController {
         FamilyDTO familyDTO = familyService.getFamily(authUser);
 
         return CommonResponse.onSuccess(familyDTO);
+    }
+
+    @ApiOperation(value = "아이들 목록 조회하기")
+    @GetMapping(value = "/kid", produces = "application/json; charset=utf-8")
+    @ResponseBody
+    public CommonResponse<List<KidListDTO>> getFamilyKidList(
+        @AuthenticationPrincipal User authUser) {
+        if (authUser.getIsKid()) {
+            throw new ForbiddenException("부모만 자녀 정보를 조회할 수 있습니다.");
+        }
+        List<KidListDTO> kidListDTOList = familyService.getKidListFromFamily(authUser);
+
+        return CommonResponse.onSuccess(kidListDTOList);
     }
 }

--- a/src/main/java/com/ceos/bankids/domain/Kid.java
+++ b/src/main/java/com/ceos/bankids/domain/Kid.java
@@ -68,9 +68,6 @@ public class Kid extends AbstractTimestamp {
         Long level,
         User user
     ) {
-        if (savings == null) {
-            throw new BadRequestException("총 저축액은 필수값입니다.");
-        }
         if (user == null) {
             throw new BadRequestException("유저는 필수값입니다.");
         }

--- a/src/main/java/com/ceos/bankids/dto/KidListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidListDTO.java
@@ -23,4 +23,5 @@ public class KidListDTO {
         this.isFemale = user.getIsFemale();
         this.level = user.getKid().getLevel();
     }
+
 }

--- a/src/main/java/com/ceos/bankids/dto/KidListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidListDTO.java
@@ -1,0 +1,26 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.User;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+public class KidListDTO {
+
+    @ApiModelProperty(example = "주어랑")
+    String username;
+    @ApiModelProperty(example = "true")
+    Boolean isFemale;
+    @ApiModelProperty(example = "1")
+    Long level;
+
+    public KidListDTO(User user) {
+        this.username = user.getUsername();
+        this.isFemale = user.getIsFemale();
+        this.level = user.getKid().getLevel();
+    }
+}

--- a/src/main/java/com/ceos/bankids/service/FamilyService.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyService.java
@@ -4,15 +4,20 @@ import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.FamilyUserDTO;
+import com.ceos.bankids.dto.KidListDTO;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface FamilyService {
 
+
     public FamilyDTO postNewFamily(User user);
 
     public List<FamilyUserDTO> getFamilyUserList(Family family);
 
     public FamilyDTO getFamily(User user);
+
+    public List<KidListDTO> getKidListFromFamily(User user);
+
 }

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -10,6 +10,8 @@ import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.repository.FamilyRepository;
 import com.ceos.bankids.repository.FamilyUserRepository;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -104,10 +106,19 @@ public class FamilyServiceImpl implements FamilyService {
             List<KidListDTO> kidListDTOList = familyUserList.stream().map(FamilyUser::getUser)
                 .filter(User::getIsKid).map(KidListDTO::new).collect(
                     Collectors.toList());
+            Collections.sort(kidListDTOList, new KidListDTOComparator());
             return kidListDTOList;
         } else {
             List<KidListDTO> kidListDTOList = new ArrayList<>();
             return kidListDTOList;
+        }
+    }
+
+    class KidListDTOComparator implements Comparator<KidListDTO> {
+
+        @Override
+        public int compare(KidListDTO k1, KidListDTO k2) {
+            return k1.getUsername().compareTo(k2.getUsername());
         }
     }
 }

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -5,6 +5,7 @@ import com.ceos.bankids.domain.FamilyUser;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.FamilyUserDTO;
+import com.ceos.bankids.dto.KidListDTO;
 import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.repository.FamilyRepository;
 import com.ceos.bankids.repository.FamilyUserRepository;
@@ -23,6 +24,7 @@ public class FamilyServiceImpl implements FamilyService {
 
     private final FamilyRepository fRepo;
     private final FamilyUserRepository fuRepo;
+
 
     @Override
     @Transactional
@@ -86,6 +88,26 @@ public class FamilyServiceImpl implements FamilyService {
         } else {
             FamilyDTO familyDTO = new FamilyDTO(new Family(), new ArrayList<>());
             return familyDTO;
+        }
+    }
+
+    @Override
+    @Transactional
+    public List<KidListDTO> getKidListFromFamily(User user) {
+        Optional<FamilyUser> familyUser = fuRepo.findByUserId(user.getId());
+        if (familyUser.isPresent()) {
+            Optional<Family> family = fRepo.findById(familyUser.get().getFamily().getId());
+            if (family.isEmpty()) {
+                throw new BadRequestException("삭제된 가족입니다.");
+            }
+            List<FamilyUser> familyUserList = fuRepo.findByFamily(family.get());
+            List<KidListDTO> kidListDTOList = familyUserList.stream().map(FamilyUser::getUser)
+                .filter(User::getIsKid).map(KidListDTO::new).collect(
+                    Collectors.toList());
+            return kidListDTOList;
+        } else {
+            List<KidListDTO> kidListDTOList = new ArrayList<>();
+            return kidListDTOList;
         }
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -4,10 +4,13 @@ import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.FamilyController;
 import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.FamilyUser;
+import com.ceos.bankids.domain.Kid;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.FamilyUserDTO;
+import com.ceos.bankids.dto.KidListDTO;
 import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.exception.ForbiddenException;
 import com.ceos.bankids.repository.FamilyRepository;
 import com.ceos.bankids.repository.FamilyUserRepository;
 import com.ceos.bankids.service.FamilyServiceImpl;
@@ -25,7 +28,7 @@ public class FamilyControllerTest {
 
     @Test
     @DisplayName("생성 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
-    public void testIfFamilyExistButDeletedWhenPostThenThrowBadRequestException() {
+    public void testIfFamilyExistedButDeletedWhenPostThenThrowBadRequestException() {
         // given
         User user1 = User.builder()
             .id(1L)
@@ -270,7 +273,7 @@ public class FamilyControllerTest {
 
     @Test
     @DisplayName("조회 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
-    public void testIfFamilyExistButDeletedWhenGetThenThrowBadRequestException() {
+    public void testIfFamilyExistedButDeletedWhenGetThenThrowBadRequestException() {
         // given
         User user1 = User.builder()
             .id(1L)
@@ -317,5 +320,271 @@ public class FamilyControllerTest {
         Assertions.assertThrows(BadRequestException.class, () -> {
             familyController.getFamily(user1);
         });
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 자녀일 경우, 에러 처리 하는지 확인")
+    public void testIfAKidTryToGetKidListThenThrowForbiddenException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+
+        // then
+        Assertions.assertThrows(ForbiddenException.class, () -> {
+            familyController.getFamilyKidList(user1);
+        });
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
+    public void testIfFamilyExistedButDeletedWhenGetKidListThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.getFamilyKidList(user1);
+        });
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 결과 있을 때, 아이 리스트 정보 가나다순으로 반환하는지 확인")
+    public void testIfFamilyExistThenReturnKidListResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("성우")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("민준")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("어진")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user4 = User.builder()
+            .id(4L)
+            .username("규진")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Kid kid2 = Kid.builder().level(1L).user(user2).build();
+        Kid kid3 = Kid.builder().level(2L).user(user3).build();
+        Kid kid4 = Kid.builder().level(3L).user(user4).build();
+        user2.setKid(kid2);
+        user3.setKid(kid3);
+        user4.setKid(kid4);
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family).build();
+        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser4);
+        familyUserList.add(familyUser2);
+        familyUserList.add(familyUser3);
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+        CommonResponse<List<KidListDTO>> result = familyController.getFamilyKidList(user1);
+
+        // then
+        List<KidListDTO> kidListDTOList = familyUserList.stream().map(FamilyUser::getUser)
+            .filter(User::getIsKid).map(KidListDTO::new).collect(
+                Collectors.toList());
+        Assertions.assertEquals(CommonResponse.onSuccess(kidListDTOList), result);
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 결과 없을 때, 빈 리스트 반환하는지 확인")
+    public void testIfFamilyExistButNotKidThenReturnEmptyList() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+        CommonResponse<List<KidListDTO>> result = familyController.getFamilyKidList(user1);
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new ArrayList()), result);
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 가족 없을 때, 빈 리스트 반환하는지 확인")
+    public void testIfFamilyNotExistThenReturnEmptyList() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(null));
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService
+        );
+        CommonResponse<List<KidListDTO>> result = familyController.getFamilyKidList(user1);
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new ArrayList()), result);
     }
 }


### PR DESCRIPTION
## 📝 PR Summary
- 가족이 없거나, 가족은 있는데 아이가 없을 경우 모두 빈 리스트 리턴합니다.
- 아이가 있을 경우, 이름 가나다순으로 정렬한 리스트를 리턴합니다.
- 부모만 조회할 수 있도록 validation 걸어 Forbidden 처리했습니다.
- 데모데이 이전 마지막 API네요. 우리 수고했어유~!
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/kidList
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] 부모인지 검증
- [x] 부모 기준으로 아이 리스트 조회
- [x] 아이 정렬 (이름 가나다순)
- [x] 최소 정보만 리스트로 리턴
- [x] 테스트 코드 작성
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#48 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
