### PR TITLE
refactor: format.parse 로직 전부 calendar로 리팩

### DIFF
--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -151,7 +151,6 @@ public class ChallengeServiceImpl implements ChallengeService {
         Timestamp nowTimestamp = Timestamp.valueOf(now);
         Calendar nowCal = Calendar.getInstance();
         nowCal.setTime(nowTimestamp);
-        nowCal.add(Calendar.DATE, 14);
         Optional<ChallengeUser> deleteChallengeUserRow = challengeUserRepository.findByChallengeId(
             challengeId);
         if (deleteChallengeUserRow.isPresent()) {
@@ -170,7 +169,11 @@ public class ChallengeServiceImpl implements ChallengeService {
                 Timestamp deleteChallengeTimestamp = kid.getDeleteChallenge();
                 Calendar deleteCal = Calendar.getInstance();
                 deleteCal.setTime(deleteChallengeTimestamp);
-                if (nowCal.getTime().getTime() >= deleteCal.getTime().getTime()) {
+                deleteCal.add(Calendar.DATE, 14);
+                System.out.println(
+                    "deleteCal.getTime().toString() = " + deleteCal.getTime().toString());
+                System.out.println("nowCal = " + nowCal.getTime());
+                if (nowCal.getTime().getTime() <= deleteCal.getTime().getTime()) {
                     throw new ForbiddenException("돈길은 2주에 한번씩 삭제할 수 있습니다.");
                 }
                 Long datetime = System.currentTimeMillis();

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -92,7 +92,7 @@ public class UserServiceImpl implements UserService {
         Cookie cookie = new Cookie("refreshToken", user.getRefreshToken());
         cookie.setMaxAge(14 * 24 * 60 * 60);
         cookie.setSecure(true);
-        cookie.setHttpOnly(true);
+        cookie.setHttpOnly(false);
         cookie.setPath("/");
 
         response.addCookie(cookie);

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -229,6 +229,13 @@ public class ChallengeControllerTest {
             .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(2L)
             .interestRate(challengeRequest.getInterestRate()).build();
 
+        Challenge newChallenge6 = Challenge.builder().title(challengeRequest.getTitle())
+            .contractUser(newParent)
+            .isAchieved(0L).totalPrice(challengeRequest.getTotalPrice())
+            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(0L)
+            .interestRate(challengeRequest.getInterestRate()).build();
+
         Family newFamily = Family.builder().code("asdfasdf").build();
 
         FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
@@ -252,8 +259,11 @@ public class ChallengeControllerTest {
         ChallengeUser newChallengeUser5 = ChallengeUser.builder().user(newUser)
             .challenge(newChallenge5).member("parent").build();
 
+        ChallengeUser newChallengeUser6 = ChallengeUser.builder().user(newUser)
+            .challenge(newChallenge6).member("parent").build();
+
         List<ChallengeUser> challengeUserList = List.of(newChallengeUser1, newChallengeUser2,
-            newChallengeUser3, newChallengeUser4, newChallengeUser5);
+            newChallengeUser3, newChallengeUser4, newChallengeUser5, newChallengeUser6);
 
         List<FamilyUser> familyUserList = new ArrayList<>();
         familyUserList.add(newFamilyFather);


### PR DESCRIPTION
## 📝 PR Summary

* format.parse로 시간 계산했던 로직을 전부 timestamp를 calendar로 씌워서 계산함으로써 try/catch문 안써도 되는 로직으로 교체했습니다
#### 🌲 Working Branch

* refactor/timestamp
#### 🌲 TODOs

* slf4j 사용 로거 달기
### Related Issues

#55 
