### PR TITLE
feat: 일요일 검사 Validation 추가 및 돈길 삭제 API에서 해당 돈길 못 찾을시 400에러로 리팩토링

### DIFF
--- a/src/main/java/com/ceos/bankids/BankidsApplication.java
+++ b/src/main/java/com/ceos/bankids/BankidsApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class BankidsApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BankidsApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BankidsApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -415,7 +415,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         nowCal.setTime(nowTimestamp);
         DayOfWeek dayOfWeek = now.getDayOfWeek();
         int value = dayOfWeek.getValue();
-        if (value == 4) {
+        if (value == 7) {
             throw new ForbiddenException("일요일에는 접근 불가능한 API 입니다.");
         }
     }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -186,7 +186,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
             return null;
         } else {
-            throw new NotFoundException("챌린지가 없습니다.");
+            throw new BadRequestException("챌린지가 없습니다.");
         }
     }
 

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -29,6 +29,7 @@ import com.ceos.bankids.repository.ParentRepository;
 import com.ceos.bankids.repository.ProgressRepository;
 import com.ceos.bankids.repository.TargetItemRepository;
 import java.sql.Timestamp;
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -60,6 +61,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Override
     public ChallengeDTO createChallenge(User user, ChallengeRequest challengeRequest) {
 
+        sundayValidation();
         userRoleValidation(user, true);
         long count = challengeUserRepository.findByUserId(user.getId()).stream()
             .filter(challengeUser -> challengeUser.getChallenge().getStatus() == 2
@@ -140,6 +142,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Override
     public ChallengeDTO deleteChallenge(User user, Long challengeId) {
 
+        sundayValidation();
         userRoleValidation(user, true);
         LocalDateTime now = LocalDateTime.now();
         Timestamp nowTimestamp = Timestamp.valueOf(now);
@@ -311,6 +314,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     public ChallengeDTO updateChallengeStatus(User user, Long challengeId,
         KidChallengeRequest kidChallengeRequest) {
 
+        sundayValidation();
         userRoleValidation(user, false);
         ChallengeUser findChallengeUser = challengeUserRepository.findByChallengeId(challengeId)
             .orElseThrow(() -> new BadRequestException("존재하지 않는 돈길입니다."));
@@ -401,6 +405,18 @@ public class ChallengeServiceImpl implements ChallengeService {
     public void userRoleValidation(User user, Boolean approveRole) {
         if (user.getIsKid() != approveRole) {
             throw new ForbiddenException("접근 불가능한 API 입니다.");
+        }
+    }
+
+    public void sundayValidation() {
+        LocalDateTime now = LocalDateTime.now();
+        Timestamp nowTimestamp = Timestamp.valueOf(now);
+        Calendar nowCal = Calendar.getInstance();
+        nowCal.setTime(nowTimestamp);
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+        int value = dayOfWeek.getValue();
+        if (value == 4) {
+            throw new ForbiddenException("일요일에는 접근 불가능한 API 입니다.");
         }
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest.java
@@ -237,6 +237,96 @@ public class ChallengeControllerTest {
                 mockBindingResult));
     }
 
+//    @Test
+//    @DisplayName("챌린지 생성 요청 시, 일요일에 접근했을 때, 에러 확인")
+//    public void testIfPostChallengeSunDayForbiddenErr() {
+//
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
+//            ChallengeCategoryRepository.class);
+//        TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
+//        ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
+//        ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
+//            ChallengeUserRepository.class);
+//        ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
+//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+//        CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        BindingResult mockBindingResult = Mockito.mock(BindingResult.class);
+//        //given
+//        ChallengeRequest challengeRequest = new ChallengeRequest(true, "이자율 받기", "전자제품", "에어팟 사기",
+//            30L,
+//            150000L, 10000L, 15L);
+//
+//        User newUser = User.builder().id(1L).username("user1").isFemale(true).birthday("19990521")
+//            .authenticationCode("code").provider("kakao").isKid(true).refreshToken("token").build();
+//
+//        User newParent = User.builder().id(2L).username("parent1").isFemale(true)
+//            .birthday("19990623")
+//            .authenticationCode("code1").provider("kakao").isKid(false).refreshToken("token1")
+//            .build();
+//
+//        Parent parent = Parent.builder().user(newParent).totalChallenge(0L).totalRequest(0L)
+//            .acceptedRequest(0L).savings(0L).build();
+//        newParent.setParent(parent);
+//
+//        User newFather = User.builder().id(3L).username("parent2").isFemale(false)
+//            .birthday("19990623")
+//            .authenticationCode("code1").provider("kakao").isKid(false).refreshToken("token1")
+//            .build();
+//
+//        ChallengeCategory newChallengeCategory = ChallengeCategory.builder().id(1L)
+//            .category("이자율 받기").build();
+//
+//        TargetItem newTargetItem = TargetItem.builder().id(1L).name("전자제품").build();
+//
+//        Challenge newChallenge = Challenge.builder().title(challengeRequest.getTitle())
+//            .contractUser(newParent)
+//            .isAchieved(1L).totalPrice(challengeRequest.getTotalPrice())
+//            .weekPrice(challengeRequest.getWeekPrice()).weeks(challengeRequest.getWeeks())
+//            .challengeCategory(newChallengeCategory).targetItem(newTargetItem).status(1L)
+//            .interestRate(challengeRequest.getInterestRate()).build();
+//
+//        Family newFamily = Family.builder().code("asdfasdf").build();
+//
+//        FamilyUser newFamilyUser = FamilyUser.builder().user(newUser).family(newFamily).build();
+//
+//        FamilyUser newFamilyFather = FamilyUser.builder().user(newFather).family(newFamily).build();
+//
+//        FamilyUser newFamilyParent = FamilyUser.builder().user(newParent).family(newFamily).build();
+//
+//        List<FamilyUser> familyUserList = new ArrayList<>();
+//        familyUserList.add(newFamilyFather);
+//        familyUserList.add(newFamilyParent);
+//
+//        Mockito.when(mockFamilyUserRepository.findByUserId(newUser.getId()))
+//            .thenReturn(Optional.ofNullable(newFamilyUser));
+//        Mockito.when(mockFamilyUserRepository.findByFamily(newFamily))
+//            .thenReturn(familyUserList);
+//
+//        Mockito.when(mockChallengeRepository.save(newChallenge)).thenReturn(newChallenge);
+//        Mockito.when(mockChallengeRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(newChallenge));
+//        Mockito.when(mockTargetItemRepository.findByName(newTargetItem.getName()))
+//            .thenReturn(newTargetItem);
+//        Mockito.when(
+//                mockChallengeCategoryRepository.findByCategory(newChallengeCategory.getCategory()))
+//            .thenReturn(newChallengeCategory);
+//
+//        //when
+//        ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
+//            mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
+//            mockProgressRepository, mockFamilyUserRepository, mockCommentRepository,
+//            mockKidRepository, mockParentRepository);
+//        ChallengeController challengeController = new ChallengeController(challengeService);
+//
+//        //then
+//        Assertions.assertThrows(ForbiddenException.class,
+//            () -> challengeController.postChallenge(newUser, challengeRequest,
+//                mockBindingResult));
+//    }
+
     @Test
     @DisplayName("챌린지 생성 개수 제한 도달 시, 403 에러 테스트")
     public void testIfPostChallengeMaxCountForbiddenErr() {
@@ -1414,7 +1504,7 @@ public class ChallengeControllerTest {
         Long challengeId = newChallenge.getId();
 
         //then
-        Assertions.assertThrows(NotFoundException.class, () -> {
+        Assertions.assertThrows(BadRequestException.class, () -> {
             challengeController.deleteChallenge(newUser1, 2L);
         });
     }


### PR DESCRIPTION
## 📝 PR Summary

* 각 API에서 일요일 검사 후 일요일이면 403에러로 막는 Validation 추가
* 돈길 삭제 API에서 해당 돈길 못 찾았을 때 404 => 400에러로 리팩토링
#### 🌲 Working Branch

feature/sundayValidation

### Related Issues

#77 
