### PR TITLE
fix: v0.0.6

### DIFF
--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -225,12 +225,11 @@ public class ChallengeServiceImpl implements ChallengeService {
                 } else if (interestRate == 30L) {
                     risk = 1L;
                 }
-
                 for (Progress progress : progressList) {
                     if (createdAtCal.getTime().getTime() <= nowCal.getTime().getTime()) {
                         if (!progress.getIsAchieved()) {
                             falseCnt += 1;
-                            if (falseCnt >= risk) {
+                            if (falseCnt > risk) {
                                 challenge.setIsAchieved(0L);
                                 challenge.setStatus(0L);
                                 challengeRepository.save(challenge);
@@ -238,8 +237,6 @@ public class ChallengeServiceImpl implements ChallengeService {
                                 break;
                             }
                         }
-                        System.out.println(
-                            "progress.getIsAchieved() = " + progress.getIsAchieved());
                         progressDTOList.add(new ProgressDTO(progress));
                         createdAtCal.add(Calendar.DATE, 7);
                     }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -336,6 +336,12 @@ public class ChallengeServiceImpl implements ChallengeService {
             throw new BadRequestException("이미 승인 혹은 거절된 돈길입니다.");
         }
         if (kidChallengeRequest.getAccept()) {
+            long count = challengeUserRepository.findByUserId(cUser.getId()).stream()
+                .filter(challengeUser -> challengeUser.getChallenge().getStatus() == 2
+                    && challengeUser.getChallenge().getIsAchieved() == 1).count();
+            if (count >= 5) {
+                throw new ForbiddenException("자녀가 돈길 생성 개수 제한에 도달했습니다.");
+            }
             Kid kid = cUser.getKid();
             challenge.setStatus(2L);
             challengeRepository.save(challenge);


### PR DESCRIPTION
## 📝 PR Summary

* Ex. 부모가 돈길을 수락하기 전에 생성한 돈길에 대해서는 5개 검사 Validation이 없었기 때문에 수락에도 추가
* 이자율이 30일때, 현재 주차도 실패로 인식하여 바로 실패 때려버리는 문제 해결
#### 🌲 Working Branch

fix/v0.0.6

### Related Issues
#84 
