### PR TITLE
refactor: 가족 정보, 자녀 리스트 조회 API 수정

### DIFF
--- a/src/main/java/com/ceos/bankids/dto/KidListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidListDTO.java
@@ -11,6 +11,8 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class KidListDTO {
 
+    @ApiModelProperty(example = "1")
+    Long kidId;
     @ApiModelProperty(example = "주어랑")
     String username;
     @ApiModelProperty(example = "true")
@@ -19,9 +21,9 @@ public class KidListDTO {
     Long level;
 
     public KidListDTO(User user) {
+        this.kidId = user.getKid().getId();
         this.username = user.getUsername();
         this.isFemale = user.getIsFemale();
         this.level = user.getKid().getLevel();
     }
-
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -472,7 +472,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         nowCal.setTime(nowTimestamp);
         DayOfWeek dayOfWeek = now.getDayOfWeek();
         int value = dayOfWeek.getValue();
-        if (value == 8) {       // test환경에선 접근이 안되는 8로 실환경에선 일요일인 7로 설정
+        if (value == 7) {       // test환경에선 접근이 안되는 8로 실환경에선 일요일인 7로 설정
             throw new ForbiddenException("일요일에는 접근 불가능한 API 입니다.");
         }
     }

--- a/src/main/java/com/ceos/bankids/service/FamilyService.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyService.java
@@ -14,7 +14,7 @@ public interface FamilyService {
 
     public FamilyDTO postNewFamily(User user);
 
-    public List<FamilyUserDTO> getFamilyUserList(Family family);
+    public List<FamilyUserDTO> getFamilyUserList(Family family, User user);
 
     public FamilyDTO getFamily(User user);
 

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -40,7 +40,7 @@ public class FamilyServiceImpl implements FamilyService {
                 throw new BadRequestException("삭제된 가족입니다.");
             }
             List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(
-                familyUser.get().getFamily());
+                familyUser.get().getFamily(), user);
             FamilyDTO familyDTO = new FamilyDTO(familyUser.get().getFamily(), familyUserDTOList);
 
             return familyDTO;
@@ -57,7 +57,7 @@ public class FamilyServiceImpl implements FamilyService {
                 .build();
             fuRepo.save(newFamilyUser);
 
-            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(newFamily);
+            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(newFamily, user);
             FamilyDTO familyDTO = new FamilyDTO(newFamily, familyUserDTOList);
 
             return familyDTO;
@@ -66,10 +66,11 @@ public class FamilyServiceImpl implements FamilyService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<FamilyUserDTO> getFamilyUserList(Family family) {
+    public List<FamilyUserDTO> getFamilyUserList(Family family, User user) {
         List<FamilyUser> familyUser = fuRepo.findByFamily(family);
 
         List<FamilyUserDTO> userDTOList = familyUser.stream().map(FamilyUser::getUser)
+            .filter(u -> !u.getId().equals(user.getId()))
             .map(FamilyUserDTO::new)
             .collect(Collectors.toList());
 
@@ -85,7 +86,7 @@ public class FamilyServiceImpl implements FamilyService {
             if (family.isEmpty()) {
                 throw new BadRequestException("삭제된 가족입니다.");
             }
-            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(family.get());
+            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(family.get(), user);
             FamilyDTO familyDTO = new FamilyDTO(family.get(), familyUserDTOList);
             return familyDTO;
         } else {

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -103,7 +103,6 @@ public class FamilyControllerTest {
         FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
         FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
         List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-        familyUserList.add(familyUser1);
         familyUserList.add(familyUser2);
 
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
@@ -147,7 +146,6 @@ public class FamilyControllerTest {
         Family family = Family.builder().code("code").build();
         FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
         List<FamilyUser> familyUserList = new ArrayList<>();
-        familyUserList.add(familyUser1);
 
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
@@ -209,7 +207,6 @@ public class FamilyControllerTest {
         FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
         FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
         List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-        familyUserList.add(familyUser1);
         familyUserList.add(familyUser2);
 
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);


### PR DESCRIPTION
## 📝 PR Summary
- 기획 확정에 따른 가족 정보 관련 API 수정사항입니다.
- 민준 요청에 따라 family/kid에 kidId 추가했습니다.
- 프론트 요청에 따라 family에서 내 정보 제외하고 모든 가족의 정보 리턴했습니다.
- 일요일 접근 제한 조건 변경했습니다.
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
refactor/family
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] GET family에서 내 정보 빼고 리스트로 리턴
- [x] GET family/kid에 kidId 추가
- [x] 테스트 코드 수정
- [x] 일요일 접근 제한 조건 변경
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#97 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
