### PR TITLE
feature: 부모 마이페이지 기획 및 뷰 수정에 따라 코드 작성

### DIFF
--- a/src/main/java/com/ceos/bankids/dto/KidListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidListDTO.java
@@ -19,11 +19,20 @@ public class KidListDTO {
     Boolean isFemale;
     @ApiModelProperty(example = "1")
     Long level;
+    @ApiModelProperty(example = "200000")
+    Long savings;
+    @ApiModelProperty(example = "8")
+    Long achievedChallenge;
+    @ApiModelProperty(example = "10")
+    Long totalChallenge;
 
     public KidListDTO(User user) {
         this.kidId = user.getKid().getId();
         this.username = user.getUsername();
         this.isFemale = user.getIsFemale();
         this.level = user.getKid().getLevel();
+        this.savings = user.getKid().getSavings();
+        this.achievedChallenge = user.getKid().getAchievedChallenge();
+        this.totalChallenge = user.getKid().getTotalChallenge();
     }
 }

--- a/src/main/java/com/ceos/bankids/dto/ParentDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ParentDTO.java
@@ -11,19 +11,13 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class ParentDTO {
 
-    @ApiModelProperty(example = "15")
-    Long totalChallenge;
     @ApiModelProperty(example = "8")
     Long acceptedRequest;
     @ApiModelProperty(example = "10")
     Long totalRequest;
-    @ApiModelProperty(example = "300000")
-    Long savings;
 
     public ParentDTO(Parent parent) {
-        this.totalChallenge = parent.getTotalChallenge();
         this.acceptedRequest = parent.getAcceptedRequest();
         this.totalRequest = parent.getTotalRequest();
-        this.savings = parent.getSavings();
     }
 }


### PR DESCRIPTION
## 📝 PR Summary
- 부모 마이페이지 수정에 따라 GET user에서 부모일 경우 수정했습니다.
- ParentDTO에서 총 돈길 수와 총 저축액 삭제했습니다. 이후에 컬럼 삭제 및 챌린지 쪽 코드 수정 부탁드려요!
- 자녀 정보는 GET family/kid에서 한번에 조회할 수 있도록 총 저축액, 총 돈길, 완주율 추가했습니다.
- KidListDTO에 추가로, domain외 별 다른 코드 수정 없습니다.
- 테스트 모두 정상 작동합니다.
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/parent
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] 이전 부모 마이페이지 데이터 중 총 돈길 수와 총 저축액 제거
- [x] 수락률은 그대로 가져감
- [x] 자녀별 기록 리스트에 추가해 반환 (총 저축액, 총 돈길, 완주율)
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#106 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
