### PR TITLE
feat: 유저 탈퇴

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -1,9 +1,11 @@
 package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.controller.request.WithdrawalRequest;
 import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.KidBackupDTO;
 import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.MyPageDTO;
@@ -100,18 +102,18 @@ public class UserController {
 
         log.info("api = 유저 탈퇴, user = {}", authUser.getUsername());
 
-//        FamilyDTO familyDTO = familyService.getFamily(authUser);
-//        if (familyDTO.getCode() != null) {
-//            FamilyRequest familyRequest = new FamilyRequest(familyDTO.getCode());
-//            if (authUser.getIsKid()) {
-//                challengeService.challengeCompleteDeleteByKid(authUser, familyRequest);
-//            } else {
-//                challengeService.challengeCompleteDeleteByParent(authUser, familyRequest);
-//            }
-//
-//            FamilyDTO deletedFamilyDTO = familyService.deleteFamilyUser(authUser,
-//                familyRequest.getCode());
-//        }
+        FamilyDTO familyDTO = familyService.getFamily(authUser);
+        if (familyDTO.getCode() != null) {
+            FamilyRequest familyRequest = new FamilyRequest(familyDTO.getCode());
+            if (authUser.getIsKid()) {
+                challengeService.challengeCompleteDeleteByKid(authUser, familyRequest);
+            } else {
+                challengeService.challengeCompleteDeleteByParent(authUser, familyRequest);
+            }
+
+            FamilyDTO deletedFamilyDTO = familyService.deleteFamilyUser(authUser,
+                familyRequest.getCode());
+        }
 
         if (authUser.getIsKid()) {
             KidBackupDTO kidBackupDTO = kidBackupService.backupKidUser(authUser);

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -1,11 +1,15 @@
 package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.MyPageDTO;
 import com.ceos.bankids.dto.UserDTO;
+import com.ceos.bankids.service.ChallengeServiceImpl;
+import com.ceos.bankids.service.FamilyServiceImpl;
 import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletResponse;
@@ -15,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,6 +33,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class UserController {
 
     private final UserServiceImpl userService;
+    private final FamilyServiceImpl familyService;
+    private final ChallengeServiceImpl challengeService;
 
     @ApiOperation(value = "유저 타입 선택")
     @PatchMapping(value = "", produces = "application/json; charset=utf-8")
@@ -72,6 +79,31 @@ public class UserController {
 
         log.info("api = 유저 로그아웃, user = {}", authUser.getUsername());
         UserDTO userDTO = userService.updateUserLogout(authUser);
+
+        return CommonResponse.onSuccess(userDTO);
+    }
+
+    @ApiOperation(value = "유저 탈퇴")
+    @DeleteMapping(value = "/", produces = "application/json; charset=utf-8")
+    @ResponseBody
+    public CommonResponse<UserDTO> deleteUserAccount(@AuthenticationPrincipal User authUser) {
+
+        log.info("api = 유저 탈퇴, user = {}", authUser.getUsername());
+
+        FamilyDTO familyDTO = familyService.getFamily(authUser);
+        if (familyDTO.getCode() != null) {
+            FamilyRequest familyRequest = new FamilyRequest(familyDTO.getCode());
+            if (authUser.getIsKid()) {
+                challengeService.challengeCompleteDeleteByKid(authUser, familyRequest);
+            } else {
+                challengeService.challengeCompleteDeleteByParent(authUser, familyRequest);
+            }
+
+            FamilyDTO deletedFamilyDTO = familyService.deleteFamilyUser(authUser,
+                familyRequest.getCode());
+        }
+
+        UserDTO userDTO = null;
 
         return CommonResponse.onSuccess(userDTO);
     }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -12,7 +12,9 @@ import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.service.ChallengeServiceImpl;
 import com.ceos.bankids.service.FamilyServiceImpl;
 import com.ceos.bankids.service.KidBackupServiceImpl;
+import com.ceos.bankids.service.KidServiceImpl;
 import com.ceos.bankids.service.ParentBackupServiceImpl;
+import com.ceos.bankids.service.ParentServiceImpl;
 import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletResponse;
@@ -40,6 +42,8 @@ public class UserController {
     private final ChallengeServiceImpl challengeService;
     private final KidBackupServiceImpl kidBackupService;
     private final ParentBackupServiceImpl parentBackupService;
+    private final KidServiceImpl kidService;
+    private final ParentServiceImpl parentService;
 
     @ApiOperation(value = "유저 타입 선택")
     @PatchMapping(value = "", produces = "application/json; charset=utf-8")
@@ -113,13 +117,15 @@ public class UserController {
             KidBackupDTO kidBackupDTO = kidBackupService.backupKidUser(authUser);
             userService.sendWithdrawalMessage("KidBackup ", kidBackupDTO.getId(),
                 withdrawalRequest.getMessage());
+            kidService.deleteKid(authUser);
         } else {
             ParentBackupDTO parentBackupDTO = parentBackupService.backupParentUser(authUser);
             userService.sendWithdrawalMessage("ParentBackup ", parentBackupDTO.getId(),
                 withdrawalRequest.getMessage());
+            parentService.deleteParent(authUser);
         }
 
-        UserDTO userDTO = null;
+        UserDTO userDTO = userService.deleteUser(authUser);
 
         return CommonResponse.onSuccess(userDTO);
     }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -17,6 +17,7 @@ import com.ceos.bankids.service.KidBackupServiceImpl;
 import com.ceos.bankids.service.KidServiceImpl;
 import com.ceos.bankids.service.ParentBackupServiceImpl;
 import com.ceos.bankids.service.ParentServiceImpl;
+import com.ceos.bankids.service.SlackServiceImpl;
 import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletResponse;
@@ -46,6 +47,7 @@ public class UserController {
     private final ParentBackupServiceImpl parentBackupService;
     private final KidServiceImpl kidService;
     private final ParentServiceImpl parentService;
+    private final SlackServiceImpl slackService;
 
     @ApiOperation(value = "유저 타입 선택")
     @PatchMapping(value = "", produces = "application/json; charset=utf-8")
@@ -117,12 +119,12 @@ public class UserController {
 
         if (authUser.getIsKid()) {
             KidBackupDTO kidBackupDTO = kidBackupService.backupKidUser(authUser);
-            userService.sendWithdrawalMessage("KidBackup ", kidBackupDTO.getId(),
+            slackService.sendWithdrawalMessage("KidBackup ", kidBackupDTO.getId(),
                 withdrawalRequest.getMessage());
             kidService.deleteKid(authUser);
         } else {
             ParentBackupDTO parentBackupDTO = parentBackupService.backupParentUser(authUser);
-            userService.sendWithdrawalMessage("ParentBackup ", parentBackupDTO.getId(),
+            slackService.sendWithdrawalMessage("ParentBackup ", parentBackupDTO.getId(),
                 withdrawalRequest.getMessage());
             parentService.deleteParent(authUser);
         }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -1,10 +1,9 @@
 package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
-import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
+import com.ceos.bankids.controller.request.WithdrawalRequest;
 import com.ceos.bankids.domain.User;
-import com.ceos.bankids.dto.FamilyDTO;
 import com.ceos.bankids.dto.KidBackupDTO;
 import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.MyPageDTO;
@@ -90,29 +89,34 @@ public class UserController {
     }
 
     @ApiOperation(value = "유저 탈퇴")
-    @DeleteMapping(value = "/", produces = "application/json; charset=utf-8")
+    @DeleteMapping(value = "", produces = "application/json; charset=utf-8")
     @ResponseBody
-    public CommonResponse<UserDTO> deleteUserAccount(@AuthenticationPrincipal User authUser) {
+    public CommonResponse<UserDTO> deleteUserAccount(@AuthenticationPrincipal User authUser,
+        @Valid @RequestBody WithdrawalRequest withdrawalRequest) {
 
         log.info("api = 유저 탈퇴, user = {}", authUser.getUsername());
 
-        FamilyDTO familyDTO = familyService.getFamily(authUser);
-        if (familyDTO.getCode() != null) {
-            FamilyRequest familyRequest = new FamilyRequest(familyDTO.getCode());
-            if (authUser.getIsKid()) {
-                challengeService.challengeCompleteDeleteByKid(authUser, familyRequest);
-            } else {
-                challengeService.challengeCompleteDeleteByParent(authUser, familyRequest);
-            }
-
-            FamilyDTO deletedFamilyDTO = familyService.deleteFamilyUser(authUser,
-                familyRequest.getCode());
-        }
+//        FamilyDTO familyDTO = familyService.getFamily(authUser);
+//        if (familyDTO.getCode() != null) {
+//            FamilyRequest familyRequest = new FamilyRequest(familyDTO.getCode());
+//            if (authUser.getIsKid()) {
+//                challengeService.challengeCompleteDeleteByKid(authUser, familyRequest);
+//            } else {
+//                challengeService.challengeCompleteDeleteByParent(authUser, familyRequest);
+//            }
+//
+//            FamilyDTO deletedFamilyDTO = familyService.deleteFamilyUser(authUser,
+//                familyRequest.getCode());
+//        }
 
         if (authUser.getIsKid()) {
             KidBackupDTO kidBackupDTO = kidBackupService.backupKidUser(authUser);
+            userService.sendWithdrawalMessage("KidBackup ", kidBackupDTO.getId(),
+                withdrawalRequest.getMessage());
         } else {
             ParentBackupDTO parentBackupDTO = parentBackupService.backupParentUser(authUser);
+            userService.sendWithdrawalMessage("ParentBackup ", parentBackupDTO.getId(),
+                withdrawalRequest.getMessage());
         }
 
         UserDTO userDTO = null;

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -5,11 +5,15 @@ import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
+import com.ceos.bankids.dto.KidBackupDTO;
 import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.MyPageDTO;
+import com.ceos.bankids.dto.ParentBackupDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.service.ChallengeServiceImpl;
 import com.ceos.bankids.service.FamilyServiceImpl;
+import com.ceos.bankids.service.KidBackupServiceImpl;
+import com.ceos.bankids.service.ParentBackupServiceImpl;
 import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletResponse;
@@ -35,6 +39,8 @@ public class UserController {
     private final UserServiceImpl userService;
     private final FamilyServiceImpl familyService;
     private final ChallengeServiceImpl challengeService;
+    private final KidBackupServiceImpl kidBackupService;
+    private final ParentBackupServiceImpl parentBackupService;
 
     @ApiOperation(value = "유저 타입 선택")
     @PatchMapping(value = "", produces = "application/json; charset=utf-8")
@@ -101,6 +107,12 @@ public class UserController {
 
             FamilyDTO deletedFamilyDTO = familyService.deleteFamilyUser(authUser,
                 familyRequest.getCode());
+        }
+
+        if (authUser.getIsKid()) {
+            KidBackupDTO kidBackupDTO = kidBackupService.backupKidUser(authUser);
+        } else {
+            ParentBackupDTO parentBackupDTO = parentBackupService.backupParentUser(authUser);
         }
 
         UserDTO userDTO = null;

--- a/src/main/java/com/ceos/bankids/controller/request/WithdrawalRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/WithdrawalRequest.java
@@ -1,0 +1,22 @@
+package com.ceos.bankids.controller.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class WithdrawalRequest {
+
+    @ApiModelProperty(example = "나 탈퇴하겠어!")
+    @NotNull(message = "message may not be null")
+    private String message;
+    
+}

--- a/src/main/java/com/ceos/bankids/domain/KidBackup.java
+++ b/src/main/java/com/ceos/bankids/domain/KidBackup.java
@@ -8,17 +8,17 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "KidBackup")
 @NoArgsConstructor
-@DynamicUpdate
+@EqualsAndHashCode(of = "id")
 public class KidBackup extends AbstractTimestamp {
 
     // 공통

--- a/src/main/java/com/ceos/bankids/domain/KidBackup.java
+++ b/src/main/java/com/ceos/bankids/domain/KidBackup.java
@@ -1,0 +1,85 @@
+package com.ceos.bankids.domain;
+
+import com.ceos.bankids.exception.BadRequestException;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "KidBackup")
+@NoArgsConstructor
+@DynamicUpdate
+public class KidBackup extends AbstractTimestamp {
+
+    // 공통
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 8)
+    private String birthYear;
+
+    @Column(nullable = false)
+    private Boolean isKid;
+
+    // 자녀
+    @Column(nullable = false)
+    private Long savings;
+
+    @Column(nullable = false)
+    private Long achievedChallenge;
+
+    @Column(nullable = false)
+    private Long totalChallenge;
+
+    @Column(nullable = false)
+    private Long level;
+
+    @Builder
+    public KidBackup(
+        Long id,
+        String birthYear,
+        Boolean isKid,
+        Long savings,
+        Long achievedChallenge,
+        Long totalChallenge,
+        Long level
+    ) {
+        if (birthYear == null) {
+            throw new BadRequestException("태어난 해는 필수값입니다.");
+        }
+        if (isKid == null) {
+            throw new BadRequestException("부모/자녀 여부는 필수값입니다.");
+        }
+        if (savings == null) {
+            throw new BadRequestException("총 저금액은 필수값입니다.");
+        }
+        if (achievedChallenge == null) {
+            throw new BadRequestException("완주한 돈길 수는 필수값입니다.");
+        }
+        if (totalChallenge == null) {
+            throw new BadRequestException("총 돈길 수는 필수값입니다.");
+        }
+        if (level == null) {
+            throw new BadRequestException("레벨은 필수값입니다.");
+        }
+
+        this.id = id;
+        this.birthYear = birthYear;
+        this.isKid = isKid;
+        this.savings = savings;
+        this.achievedChallenge = achievedChallenge;
+        this.totalChallenge = totalChallenge;
+        this.level = level;
+    }
+}

--- a/src/main/java/com/ceos/bankids/domain/ParentBackup.java
+++ b/src/main/java/com/ceos/bankids/domain/ParentBackup.java
@@ -8,17 +8,17 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "ParentBackup")
 @NoArgsConstructor
-@DynamicUpdate
+@EqualsAndHashCode(of = "id")
 public class ParentBackup extends AbstractTimestamp {
 
     // 공통

--- a/src/main/java/com/ceos/bankids/domain/ParentBackup.java
+++ b/src/main/java/com/ceos/bankids/domain/ParentBackup.java
@@ -1,0 +1,69 @@
+package com.ceos.bankids.domain;
+
+import com.ceos.bankids.exception.BadRequestException;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "ParentBackup")
+@NoArgsConstructor
+@DynamicUpdate
+public class ParentBackup extends AbstractTimestamp {
+
+    // 공통
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 8)
+    private String birthYear;
+
+    @Column(nullable = false)
+    private Boolean isKid;
+
+    // 부모
+    @Column(nullable = false)
+    private Long acceptedRequest;
+
+    @Column(nullable = false)
+    private Long totalRequest;
+
+    @Builder
+    public ParentBackup(
+        Long id,
+        String birthYear,
+        Boolean isKid,
+        Long acceptedRequest,
+        Long totalRequest
+    ) {
+        if (birthYear == null) {
+            throw new BadRequestException("태어난 해는 필수값입니다.");
+        }
+        if (isKid == null) {
+            throw new BadRequestException("부모/자녀 여부는 필수값입니다.");
+        }
+        if (acceptedRequest == null) {
+            throw new BadRequestException("수락한 요청 수는 필수값입니다.");
+        }
+        if (totalRequest == null) {
+            throw new BadRequestException("총 요청 수는 필수값입니다.");
+        }
+
+        this.id = id;
+        this.birthYear = birthYear;
+        this.isKid = isKid;
+        this.acceptedRequest = acceptedRequest;
+        this.totalRequest = totalRequest;
+    }
+}

--- a/src/main/java/com/ceos/bankids/dto/FamilyUserDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/FamilyUserDTO.java
@@ -12,11 +12,11 @@ import lombok.ToString;
 public class FamilyUserDTO {
 
     @ApiModelProperty(example = "주어랑")
-    String username;
+    private String username;
     @ApiModelProperty(example = "true")
-    Boolean isFemale;
+    private Boolean isFemale;
     @ApiModelProperty(example = "true")
-    Boolean isKid;
+    private Boolean isKid;
 
 
     public FamilyUserDTO(User user) {

--- a/src/main/java/com/ceos/bankids/dto/KidBackupDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidBackupDTO.java
@@ -1,7 +1,17 @@
 package com.ceos.bankids.dto;
 
 import com.ceos.bankids.domain.KidBackup;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+@EqualsAndHashCode
 public class KidBackupDTO {
 
     private String birthYear;

--- a/src/main/java/com/ceos/bankids/dto/KidBackupDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidBackupDTO.java
@@ -1,0 +1,22 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.KidBackup;
+
+public class KidBackupDTO {
+
+    private String birthYear;
+    private Boolean isKid;
+    private Long savings;
+    private Long achievedChallenge;
+    private Long totalChallenge;
+    private Long level;
+
+    public KidBackupDTO(KidBackup kid) {
+        this.birthYear = kid.getBirthYear();
+        this.isKid = kid.getIsKid();
+        this.savings = kid.getSavings();
+        this.achievedChallenge = kid.getAchievedChallenge();
+        this.totalChallenge = kid.getTotalChallenge();
+        this.level = kid.getLevel();
+    }
+}

--- a/src/main/java/com/ceos/bankids/dto/KidBackupDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidBackupDTO.java
@@ -14,6 +14,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class KidBackupDTO {
 
+    private Long id;
     private String birthYear;
     private Boolean isKid;
     private Long savings;
@@ -22,6 +23,7 @@ public class KidBackupDTO {
     private Long level;
 
     public KidBackupDTO(KidBackup kid) {
+        this.id = kid.getId();
         this.birthYear = kid.getBirthYear();
         this.isKid = kid.getIsKid();
         this.savings = kid.getSavings();

--- a/src/main/java/com/ceos/bankids/dto/KidDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidDTO.java
@@ -12,11 +12,11 @@ import lombok.ToString;
 public class KidDTO {
 
     @ApiModelProperty(example = "8")
-    Long achievedChallenge;
+    private Long achievedChallenge;
     @ApiModelProperty(example = "10")
-    Long totalChallenge;
+    private Long totalChallenge;
     @ApiModelProperty(example = "1")
-    Long level;
+    private Long level;
 
     public KidDTO(Kid kid) {
         this.achievedChallenge = kid.getAchievedChallenge();

--- a/src/main/java/com/ceos/bankids/dto/KidListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidListDTO.java
@@ -12,19 +12,19 @@ import lombok.ToString;
 public class KidListDTO {
 
     @ApiModelProperty(example = "1")
-    Long kidId;
+    private Long kidId;
     @ApiModelProperty(example = "주어랑")
-    String username;
+    private String username;
     @ApiModelProperty(example = "true")
-    Boolean isFemale;
+    private Boolean isFemale;
     @ApiModelProperty(example = "1")
-    Long level;
+    private Long level;
     @ApiModelProperty(example = "200000")
-    Long savings;
+    private Long savings;
     @ApiModelProperty(example = "8")
-    Long achievedChallenge;
+    private Long achievedChallenge;
     @ApiModelProperty(example = "10")
-    Long totalChallenge;
+    private Long totalChallenge;
 
     public KidListDTO(User user) {
         this.kidId = user.getKid().getId();

--- a/src/main/java/com/ceos/bankids/dto/MyPageDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/MyPageDTO.java
@@ -11,11 +11,11 @@ import lombok.ToString;
 public class MyPageDTO {
 
     @ApiModelProperty(example = "UserDTO")
-    UserDTO user;
+    private UserDTO user;
     @ApiModelProperty(example = "KidDTO")
-    KidDTO kid;
+    private KidDTO kid;
     @ApiModelProperty(example = "ParentDTO")
-    ParentDTO parent;
+    private ParentDTO parent;
 
     public MyPageDTO(UserDTO userDTO, KidDTO kidDTO) {
         this.user = userDTO;

--- a/src/main/java/com/ceos/bankids/dto/ParentBackupDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ParentBackupDTO.java
@@ -1,0 +1,18 @@
+package com.ceos.bankids.dto;
+
+import com.ceos.bankids.domain.ParentBackup;
+
+public class ParentBackupDTO {
+
+    private String birthYear;
+    private Boolean isKid;
+    private Long acceptedRequest;
+    private Long totalRequest;
+
+    public ParentBackupDTO(ParentBackup parent) {
+        this.birthYear = parent.getBirthYear();
+        this.isKid = parent.getIsKid();
+        this.acceptedRequest = parent.getAcceptedRequest();
+        this.totalRequest = parent.getTotalRequest();
+    }
+}

--- a/src/main/java/com/ceos/bankids/dto/ParentBackupDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ParentBackupDTO.java
@@ -1,7 +1,17 @@
 package com.ceos.bankids.dto;
 
 import com.ceos.bankids.domain.ParentBackup;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+@EqualsAndHashCode
 public class ParentBackupDTO {
 
     private String birthYear;

--- a/src/main/java/com/ceos/bankids/dto/ParentBackupDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ParentBackupDTO.java
@@ -14,12 +14,14 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class ParentBackupDTO {
 
+    private Long id;
     private String birthYear;
     private Boolean isKid;
     private Long acceptedRequest;
     private Long totalRequest;
 
     public ParentBackupDTO(ParentBackup parent) {
+        this.id = parent.getId();
         this.birthYear = parent.getBirthYear();
         this.isKid = parent.getIsKid();
         this.acceptedRequest = parent.getAcceptedRequest();

--- a/src/main/java/com/ceos/bankids/dto/ParentDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/ParentDTO.java
@@ -12,9 +12,9 @@ import lombok.ToString;
 public class ParentDTO {
 
     @ApiModelProperty(example = "8")
-    Long acceptedRequest;
+    private Long acceptedRequest;
     @ApiModelProperty(example = "10")
-    Long totalRequest;
+    private Long totalRequest;
 
     public ParentDTO(Parent parent) {
         this.acceptedRequest = parent.getAcceptedRequest();

--- a/src/main/java/com/ceos/bankids/dto/UserDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/UserDTO.java
@@ -12,15 +12,15 @@ import lombok.ToString;
 public class UserDTO {
 
     @ApiModelProperty(example = "주어랑")
-    String username;
+    private String username;
     @ApiModelProperty(example = "true")
-    Boolean isFemale;
+    private Boolean isFemale;
     @ApiModelProperty(example = "true")
-    Boolean isKid;
+    private Boolean isKid;
     @ApiModelProperty(example = "19990521")
-    String birthday;
+    private String birthday;
     @ApiModelProperty(example = "01019990521")
-    String phone;
+    private String phone;
 
 
     public UserDTO(User user) {

--- a/src/main/java/com/ceos/bankids/repository/KidBackupRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/KidBackupRepository.java
@@ -1,0 +1,8 @@
+package com.ceos.bankids.repository;
+
+import com.ceos.bankids.domain.KidBackup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KidBackupRepository extends JpaRepository<KidBackup, Long> {
+
+}

--- a/src/main/java/com/ceos/bankids/repository/ParentBackupRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/ParentBackupRepository.java
@@ -1,0 +1,8 @@
+package com.ceos.bankids.repository;
+
+import com.ceos.bankids.domain.ParentBackup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParentBackupRepository extends JpaRepository<ParentBackup, Long> {
+
+}

--- a/src/main/java/com/ceos/bankids/service/AppleServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/AppleServiceImpl.java
@@ -53,8 +53,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = false)
-
 public class AppleServiceImpl implements AppleService {
 
     private final UserRepository uRepo;

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -501,7 +501,6 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Transactional
     public void challengeCompleteDeleteByKid(User user, FamilyRequest familyRequest) {
         //ToDo: 부모는 가족나가면 어케되냐?
-        System.out.println(user.getUsername() + "!!!!");
         userRoleValidation(user, true);
         List<ChallengeUser> challengeUserList = challengeUserRepository.findByUserId(user.getId());
         List<Challenge> challengeList = challengeUserList.stream().map(ChallengeUser::getChallenge)

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -501,6 +501,7 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Transactional
     public void challengeCompleteDeleteByKid(User user, FamilyRequest familyRequest) {
         //ToDo: 부모는 가족나가면 어케되냐?
+        System.out.println(user.getUsername() + "!!!!");
         userRoleValidation(user, true);
         List<ChallengeUser> challengeUserList = challengeUserRepository.findByUserId(user.getId());
         List<Challenge> challengeList = challengeUserList.stream().map(ChallengeUser::getChallenge)

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = false)
 public class KakaoServiceImpl implements KakaoService {
 
     private final UserRepository uRepo;

--- a/src/main/java/com/ceos/bankids/service/KidBackupService.java
+++ b/src/main/java/com/ceos/bankids/service/KidBackupService.java
@@ -1,0 +1,12 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.KidBackupDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface KidBackupService {
+
+    public KidBackupDTO backupKidUser(User user);
+
+}

--- a/src/main/java/com/ceos/bankids/service/KidBackupServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KidBackupServiceImpl.java
@@ -1,7 +1,9 @@
 package com.ceos.bankids.service;
 
+import com.ceos.bankids.domain.KidBackup;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.KidBackupDTO;
+import com.ceos.bankids.repository.KidBackupRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,10 +12,22 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class KidBackupServiceImpl implements KidBackupService {
 
+    private final KidBackupRepository kidBackupRepository;
+
     @Override
     @Transactional
     public KidBackupDTO backupKidUser(User user) {
-        return null;
+        KidBackup kidBackup = KidBackup.builder()
+            .birthYear(user.getBirthday().substring(0, 4))
+            .isKid(user.getIsKid())
+            .savings(user.getKid().getSavings())
+            .achievedChallenge(user.getKid().getAchievedChallenge())
+            .totalChallenge(user.getKid().getTotalChallenge())
+            .level(user.getKid().getLevel())
+            .build();
+        kidBackupRepository.save(kidBackup);
+
+        return new KidBackupDTO(kidBackup);
     }
 
 }

--- a/src/main/java/com/ceos/bankids/service/KidBackupServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KidBackupServiceImpl.java
@@ -1,0 +1,19 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.KidBackupDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class KidBackupServiceImpl implements KidBackupService {
+
+    @Override
+    @Transactional
+    public KidBackupDTO backupKidUser(User user) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/ceos/bankids/service/KidService.java
+++ b/src/main/java/com/ceos/bankids/service/KidService.java
@@ -1,0 +1,11 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface KidService {
+
+    public void deleteKid(User user);
+
+}

--- a/src/main/java/com/ceos/bankids/service/KidServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KidServiceImpl.java
@@ -1,0 +1,21 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.repository.KidRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class KidServiceImpl implements KidService {
+
+    private final KidRepository kidRepository;
+
+    @Override
+    @Transactional
+    public void deleteKid(User user) {
+        kidRepository.delete(user.getKid());
+    }
+
+}

--- a/src/main/java/com/ceos/bankids/service/ParentBackupService.java
+++ b/src/main/java/com/ceos/bankids/service/ParentBackupService.java
@@ -1,0 +1,11 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.ParentBackupDTO;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ParentBackupService {
+
+    public ParentBackupDTO backupParentUser(User user);
+}

--- a/src/main/java/com/ceos/bankids/service/ParentBackupServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ParentBackupServiceImpl.java
@@ -1,7 +1,9 @@
 package com.ceos.bankids.service;
 
+import com.ceos.bankids.domain.ParentBackup;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.ParentBackupDTO;
+import com.ceos.bankids.repository.ParentBackupRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,10 +12,20 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ParentBackupServiceImpl implements ParentBackupService {
 
+    private final ParentBackupRepository parentBackupRepository;
+
     @Override
     @Transactional
     public ParentBackupDTO backupParentUser(User user) {
-        return null;
+        ParentBackup parentBackup = ParentBackup.builder()
+            .birthYear(user.getBirthday().substring(0, 4))
+            .isKid(user.getIsKid())
+            .acceptedRequest(user.getParent().getAcceptedRequest())
+            .totalRequest(user.getParent().getTotalRequest())
+            .build();
+        parentBackupRepository.save(parentBackup);
+
+        return new ParentBackupDTO(parentBackup);
     }
 
 }

--- a/src/main/java/com/ceos/bankids/service/ParentBackupServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ParentBackupServiceImpl.java
@@ -1,0 +1,19 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.ParentBackupDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ParentBackupServiceImpl implements ParentBackupService {
+
+    @Override
+    @Transactional
+    public ParentBackupDTO backupParentUser(User user) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/ceos/bankids/service/ParentService.java
+++ b/src/main/java/com/ceos/bankids/service/ParentService.java
@@ -1,0 +1,11 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ParentService {
+
+    public void deleteParent(User user);
+
+}

--- a/src/main/java/com/ceos/bankids/service/ParentServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ParentServiceImpl.java
@@ -1,0 +1,21 @@
+package com.ceos.bankids.service;
+
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.repository.ParentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ParentServiceImpl implements ParentService {
+
+    private final ParentRepository parentRepository;
+
+    @Override
+    @Transactional
+    public void deleteParent(User user) {
+        parentRepository.delete(user.getParent());
+    }
+
+}

--- a/src/main/java/com/ceos/bankids/service/SlackService.java
+++ b/src/main/java/com/ceos/bankids/service/SlackService.java
@@ -1,0 +1,9 @@
+package com.ceos.bankids.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface SlackService {
+
+    public void sendWithdrawalMessage(String user, Long id, String message);
+}

--- a/src/main/java/com/ceos/bankids/service/SlackServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/SlackServiceImpl.java
@@ -1,0 +1,31 @@
+package com.ceos.bankids.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class SlackServiceImpl implements SlackService {
+
+    @Value("${withdrawal.slack.webhook-uri}")
+    private String SLACK_WITHDRAWAL_URI;
+
+    @Override
+    public void sendWithdrawalMessage(String user, Long id, String message) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("username", user + id);
+        request.put("text", message);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request);
+
+        restTemplate.exchange(SLACK_WITHDRAWAL_URI, HttpMethod.POST, entity, String.class);
+    }
+}

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -22,4 +22,6 @@ public interface UserService {
     public UserDTO updateUserLogout(User authUser);
 
     public void sendWithdrawalMessage(String user, Long id, String message);
+
+    public UserDTO deleteUser(User user);
 }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -20,8 +20,6 @@ public interface UserService {
     public User getUserByRefreshToken(String refreshToken);
 
     public UserDTO updateUserLogout(User authUser);
-
-    public void sendWithdrawalMessage(String user, Long id, String message);
-
+    
     public UserDTO deleteUser(User user);
 }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -20,4 +20,6 @@ public interface UserService {
     public User getUserByRefreshToken(String refreshToken);
 
     public UserDTO updateUserLogout(User authUser);
+
+    public void sendWithdrawalMessage(String user, Long id, String message);
 }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
@@ -165,7 +164,7 @@ public class UserServiceImpl implements UserService {
 
         HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request);
 
-        restTemplate.exchange(SLACK_WITHDRAWAL_URI, HttpMethod.POST, entity, String.class);
+//        restTemplate.exchange(SLACK_WITHDRAWAL_URI, HttpMethod.POST, entity, String.class);
     }
 
     @Override

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -16,17 +16,12 @@ import com.ceos.bankids.repository.KidRepository;
 import com.ceos.bankids.repository.ParentRepository;
 import com.ceos.bankids.repository.UserRepository;
 import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -36,10 +31,6 @@ public class UserServiceImpl implements UserService {
     private final KidRepository kRepo;
     private final ParentRepository pRepo;
     private final JwtTokenServiceImpl jwtTokenServiceImpl;
-
-    @Value("${withdrawal.slack.webhook-uri}")
-    private String SLACK_WITHDRAWAL_URI;
-
 
     @Override
     @Transactional
@@ -152,19 +143,6 @@ public class UserServiceImpl implements UserService {
         cookie.setPath("/");
 
         return null;
-    }
-
-    @Override
-    public void sendWithdrawalMessage(String user, Long id, String message) {
-        RestTemplate restTemplate = new RestTemplate();
-
-        Map<String, Object> request = new HashMap<>();
-        request.put("username", user + id);
-        request.put("text", message);
-
-        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request);
-
-//        restTemplate.exchange(SLACK_WITHDRAWAL_URI, HttpMethod.POST, entity, String.class);
     }
 
     @Override

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -167,4 +167,11 @@ public class UserServiceImpl implements UserService {
 
         restTemplate.exchange(SLACK_WITHDRAWAL_URI, HttpMethod.POST, entity, String.class);
     }
+
+    @Override
+    public UserDTO deleteUser(User user) {
+        UserDTO userDTO = new UserDTO(user);
+        uRepo.delete(user);
+        return userDTO;
+    }
 }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -16,12 +16,18 @@ import com.ceos.bankids.repository.KidRepository;
 import com.ceos.bankids.repository.ParentRepository;
 import com.ceos.bankids.repository.UserRepository;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -31,6 +37,10 @@ public class UserServiceImpl implements UserService {
     private final KidRepository kRepo;
     private final ParentRepository pRepo;
     private final JwtTokenServiceImpl jwtTokenServiceImpl;
+
+    @Value("${withdrawal.slack.webhook-uri}")
+    private String SLACK_WITHDRAWAL_URI;
+
 
     @Override
     @Transactional
@@ -143,5 +153,18 @@ public class UserServiceImpl implements UserService {
         cookie.setPath("/");
 
         return null;
+    }
+
+    @Override
+    public void sendWithdrawalMessage(String user, Long id, String message) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        Map<String, Object> request = new HashMap<>();
+        request.put("username", user + id);
+        request.put("text", message);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(request);
+
+        restTemplate.exchange(SLACK_WITHDRAWAL_URI, HttpMethod.POST, entity, String.class);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,3 +30,4 @@ apple.client.id=${APPLE_CLIENT_ID}
 apple.key.id=${APPLE_KEY}
 apple.key.path=apple-auth-key.p8
 apple.nonce=${APPLE_NONCE}
+withdrawal.slack.webhook-uri=${SLACK_WITHDRAWAL_URI}

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -2,7 +2,6 @@ package com.ceos.bankids.unit.controller;
 
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.FamilyController;
-import com.ceos.bankids.controller.NotificationController;
 import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.FamilyUser;
@@ -14,16 +13,8 @@ import com.ceos.bankids.dto.FamilyUserDTO;
 import com.ceos.bankids.dto.KidListDTO;
 import com.ceos.bankids.exception.BadRequestException;
 import com.ceos.bankids.exception.ForbiddenException;
-import com.ceos.bankids.repository.ChallengeCategoryRepository;
-import com.ceos.bankids.repository.ChallengeRepository;
-import com.ceos.bankids.repository.ChallengeUserRepository;
-import com.ceos.bankids.repository.CommentRepository;
 import com.ceos.bankids.repository.FamilyRepository;
 import com.ceos.bankids.repository.FamilyUserRepository;
-import com.ceos.bankids.repository.KidRepository;
-import com.ceos.bankids.repository.ParentRepository;
-import com.ceos.bankids.repository.ProgressRepository;
-import com.ceos.bankids.repository.TargetItemRepository;
 import com.ceos.bankids.service.ChallengeServiceImpl;
 import com.ceos.bankids.service.FamilyServiceImpl;
 import java.util.ArrayList;
@@ -37,25 +28,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class FamilyControllerTest {
-
-    ChallengeCategoryRepository mockChallengeCategoryRepository = Mockito.mock(
-        ChallengeCategoryRepository.class);
-    TargetItemRepository mockTargetItemRepository = Mockito.mock(TargetItemRepository.class);
-    ChallengeRepository mockChallengeRepository = Mockito.mock(ChallengeRepository.class);
-    ChallengeUserRepository mockChallengeUserRepository = Mockito.mock(
-        ChallengeUserRepository.class);
-    ProgressRepository mockProgressRepository = Mockito.mock(ProgressRepository.class);
-    FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-    CommentRepository mockCommentRepository = Mockito.mock(CommentRepository.class);
-    KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-    ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-    NotificationController mockNotificationController = Mockito.mock(
-        NotificationController.class);
-    FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-    ChallengeServiceImpl challengeService = new ChallengeServiceImpl(mockChallengeRepository,
-        mockChallengeCategoryRepository, mockTargetItemRepository, mockChallengeUserRepository,
-        mockProgressRepository, mockFamilyUserRepository, mockCommentRepository,
-        mockKidRepository, mockParentRepository, mockNotificationController, mockFamilyRepository);
 
     @Test
     @DisplayName("생성 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
@@ -86,7 +58,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser1);
         familyUserList.add(familyUser2);
 
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -138,6 +110,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser1);
         familyUserList.add(familyUser2);
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -181,6 +154,7 @@ public class FamilyControllerTest {
         FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
         List<FamilyUser> familyUserList = new ArrayList<>();
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
@@ -243,6 +217,7 @@ public class FamilyControllerTest {
         List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
         familyUserList.add(familyUser2);
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -256,7 +231,8 @@ public class FamilyControllerTest {
             mockFamilyUserRepository
         );
         FamilyController familyController = new FamilyController(
-            familyService, challengeService
+            familyService,
+            challengeService
         );
         CommonResponse<FamilyDTO> result = familyController.getFamily(user1);
 
@@ -281,6 +257,7 @@ public class FamilyControllerTest {
             .isFemale(true)
             .build();
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
@@ -292,7 +269,8 @@ public class FamilyControllerTest {
             mockFamilyUserRepository
         );
         FamilyController familyController = new FamilyController(
-            familyService, challengeService
+            familyService,
+            challengeService
         );
         CommonResponse<FamilyDTO> result = familyController.getFamily(user1);
 
@@ -331,6 +309,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser1);
         familyUserList.add(familyUser2);
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -382,6 +361,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser1);
         familyUserList.add(familyUser2);
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -433,6 +413,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser1);
         familyUserList.add(familyUser2);
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -512,6 +493,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser2);
         familyUserList.add(familyUser3);
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -565,6 +547,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser1);
         familyUserList.add(familyUser2);
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -600,6 +583,7 @@ public class FamilyControllerTest {
             .isFemale(true)
             .build();
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
@@ -650,6 +634,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser2);
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
         Mockito.when(mockFamilyRepository.findByCode("test"))
@@ -705,6 +690,7 @@ public class FamilyControllerTest {
         List<FamilyUser> familyUserList = new ArrayList<>();
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findByCode("test"))
             .thenReturn(Optional.ofNullable(family2));
@@ -758,6 +744,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser1);
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
         Mockito.when(mockFamilyRepository.findByCode("test"))
@@ -846,6 +833,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser5);
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
         Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
@@ -923,6 +911,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser5);
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findByCode("test"))
             .thenReturn(Optional.ofNullable(family2));
@@ -1021,6 +1010,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser5);
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
         Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
@@ -1098,6 +1088,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser5);
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findByCode("test"))
             .thenReturn(Optional.ofNullable(family2));
@@ -1148,6 +1139,7 @@ public class FamilyControllerTest {
 
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(null));
         Mockito.when(mockFamilyRepository.findByCode("test"))
@@ -1223,6 +1215,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser5);
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         Mockito.when(mockFamilyRepository.findByCode("test"))
             .thenReturn(Optional.ofNullable(family2));
@@ -1248,8 +1241,8 @@ public class FamilyControllerTest {
     }
 
     @Test
-    @DisplayName("유저 가족 나가기 성공 시, 결과 반환 하는지 확인")
-    public void testIfFamilyUserDeleteSucceedThenReturnResult() {
+    @DisplayName("부모 가족 나가기 성공 시, 결과 반환 하는지 확인")
+    public void testIfParentFamilyUserDeleteSucceedThenReturnResult() {
         // given
         User user1 = User.builder()
             .id(1L)
@@ -1282,6 +1275,7 @@ public class FamilyControllerTest {
         familyUserList.add(familyUser3);
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
@@ -1295,6 +1289,77 @@ public class FamilyControllerTest {
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
+        );
+        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
+
+        // then
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
+            .map(FamilyUserDTO::new).collect(Collectors.toList());
+        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
+
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("자녀 가족 나가기 성공 시, 결과 반환 하는지 확인")
+    public void testIfKidFamilyUserDeleteSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(null)
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("user3")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+
+        Kid kid = Kid.builder()
+            .id(1L)
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user1)
+            .build();
+
+        user1.setKid(kid);
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser3);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService,
+            challengeService
         );
         CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
 
@@ -1334,6 +1399,7 @@ public class FamilyControllerTest {
         List<FamilyUser> familyUserList = new ArrayList<>();
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
@@ -1390,6 +1456,7 @@ public class FamilyControllerTest {
         List<FamilyUser> familyUserList = new ArrayList<>();
         FamilyRequest familyRequest = new FamilyRequest("test");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
@@ -1412,8 +1479,54 @@ public class FamilyControllerTest {
     }
 
     @Test
-    @DisplayName("유저가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
-    public void testIfFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
+    @DisplayName("자녀가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
+    public void testIfKidFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(null)
+            .build();
+
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+
+        user1.setParent(parent);
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        FamilyRequest familyRequest = new FamilyRequest("code");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        FamilyController familyController = new FamilyController(
+            familyService, challengeService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.deleteFamilyUser(user1, familyRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("부모가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
+    public void testIfParentFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
         // given
         User user1 = User.builder()
             .id(1L)
@@ -1435,6 +1548,7 @@ public class FamilyControllerTest {
         List<FamilyUser> familyUserList = new ArrayList<>();
         FamilyRequest familyRequest = new FamilyRequest("code");
 
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -1,719 +1,719 @@
-package com.ceos.bankids.unit.controller;
-
-import com.ceos.bankids.config.CommonResponse;
-import com.ceos.bankids.controller.UserController;
-import com.ceos.bankids.controller.request.UserTypeRequest;
-import com.ceos.bankids.domain.Kid;
-import com.ceos.bankids.domain.Parent;
-import com.ceos.bankids.domain.User;
-import com.ceos.bankids.dto.KidDTO;
-import com.ceos.bankids.dto.LoginDTO;
-import com.ceos.bankids.dto.MyPageDTO;
-import com.ceos.bankids.dto.ParentDTO;
-import com.ceos.bankids.dto.TokenDTO;
-import com.ceos.bankids.dto.UserDTO;
-import com.ceos.bankids.exception.BadRequestException;
-import com.ceos.bankids.repository.KidRepository;
-import com.ceos.bankids.repository.ParentRepository;
-import com.ceos.bankids.repository.UserRepository;
-import com.ceos.bankids.service.JwtTokenServiceImpl;
-import com.ceos.bankids.service.UserServiceImpl;
-import java.util.Optional;
-import javax.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
-
-public class UserControllerTest {
-
-    @Test
-    @DisplayName("유저 타입 패치 성공시, 결과 반환 하는지 확인")
-    public void testIfUserTypePatchSucceedReturnResult() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .authenticationCode("code")
-            .provider("kakao")
-            .refreshToken("token")
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-        CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
-
-        // then
-        user.setBirthday("19990521");
-        user.setIsFemale(false);
-        user.setIsKid(true);
-        UserDTO userDTO = new UserDTO(user);
-        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-    }
-
-    @Test
-    @DisplayName("유저 정보 이미 있어 실패시, 에러 처리 되는지 확인")
-    public void testIfUserTypePatchFailWhenAlreadyPatchedThrowBadRequestException() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(true)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(true)
-            .refreshToken("token")
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        // then
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            userController.patchUserType(user, userTypeRequest);
-        });
-    }
-
-    @Test
-    @DisplayName("body 없어서 패치 실패시, 에러 처리 되는지 확인")
-    public void testIfUserTypePatchFailWithoutArgumentsThrowNullPointerException() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .authenticationCode("code")
-            .provider("kakao")
-            .refreshToken("token")
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        // then
-        Assertions.assertThrows(NullPointerException.class, () -> {
-            userController.patchUserType(user, null);
-        });
-    }
-
-    @Test
-    @DisplayName("인증 유저 없어서 패치 실패시, 에러 처리 되는지 확인")
-    public void testIfUserTypePatchFailWithoutValidUserThrowBadRequestException() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .authenticationCode("code")
-            .provider("kakao")
-            .refreshToken("token")
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(null));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        // then
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            userController.patchUserType(user, userTypeRequest);
-        });
-    }
-
-    @Test
-    @DisplayName("100세 초과 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
-    public void testIfUserTypePatchFailWithTooEarlyBirthdayThrowBadRequestException() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .authenticationCode("code")
-            .provider("kakao")
-            .refreshToken("token")
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("18880818", false, true);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        // then
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            userController.patchUserType(user, userTypeRequest);
-        });
-    }
-
-    @Test
-    @DisplayName("0세 미만 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
-    public void testIfUserTypePatchFailWithTooLateBirthdayThrowBadRequestException() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .authenticationCode("code")
-            .provider("kakao")
-            .refreshToken("token")
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("23450818", false, true);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        // then
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            userController.patchUserType(user, userTypeRequest);
-        });
-    }
-
-    @Test
-    @DisplayName("자녀 지정시, 자녀 row 생성 확인")
-    public void testIfKidInsertSucceedWhenUserTypePatchSucceed() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .authenticationCode("code")
-            .provider("kakao")
-            .refreshToken("token")
-            .build();
-        Kid kid = Kid.builder()
-            .savings(0L)
-            .user(user)
-            .level(1L)
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        Mockito.when(mockKidRepository.save(kid)).thenReturn(kid);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-        CommonResponse result = userController.patchUserType(user, userTypeRequest);
-
-        // then
-        user.setBirthday("19990521");
-        user.setIsFemale(false);
-        user.setIsKid(true);
-        UserDTO userDTO = new UserDTO(user);
-
-        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-        ArgumentCaptor<Kid> kCaptor = ArgumentCaptor.forClass(Kid.class);
-        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-        Mockito.verify(mockKidRepository, Mockito.times(1)).save(kCaptor.capture());
-
-        Assertions.assertEquals(user, uCaptor.getValue());
-        Assertions.assertEquals(kid, kCaptor.getValue());
-
-        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-    }
-
-    @Test
-    @DisplayName("부모 지정시, 부모 row 생성 확인")
-    public void testIfParentInsertSucceedWhenUserTypePatchSucceed() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .authenticationCode("code")
-            .provider("kakao")
-            .refreshToken("token")
-            .build();
-        Parent parent = Parent.builder()
-            .user(user)
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", true, false);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        Mockito.when(mockParentRepository.save(parent)).thenReturn(parent);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-        CommonResponse result = userController.patchUserType(user, userTypeRequest);
-
-        // then
-        user.setBirthday("19990521");
-        user.setIsFemale(true);
-        user.setIsKid(false);
-        UserDTO userDTO = new UserDTO(user);
-
-        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-        ArgumentCaptor<Parent> pCaptor = ArgumentCaptor.forClass(Parent.class);
-        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-        Mockito.verify(mockParentRepository, Mockito.times(1)).save(pCaptor.capture());
-
-        Assertions.assertEquals(user, uCaptor.getValue());
-        Assertions.assertEquals(parent, pCaptor.getValue());
-
-        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-    }
-
-    @Test
-    @DisplayName("이미 타입을 선택한 유저 접근시, 에러 처리 되는지 확인")
-    public void testIfUserTypePatchFailWhenAlreadyRegisteredThrowBadRequestException() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(true)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(false)
-            .refreshToken("token")
-            .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(null));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        // then
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            userController.patchUserType(user, userTypeRequest);
-        });
-    }
-
-    @Test
-    @DisplayName("부모 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-    public void testIfParentTokenRefreshSucceedThenReturnResult() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(true)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(false)
-            .refreshToken("token")
-            .build();
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-        TokenDTO tokenDTO = new TokenDTO(user);
-        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
-
-        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        CommonResponse result = userController.refreshUserToken("rT", response);
-
-        // then
-        LoginDTO loginDTO = new LoginDTO(false, "aT");
-        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-    }
-
-    @Test
-    @DisplayName("자녀 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-    public void testIfKidTokenRefreshSucceedThenReturnResult() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(true)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(true)
-            .refreshToken("token")
-            .build();
-        Kid kid = Kid.builder()
-            .level(1L)
-            .user(user)
-            .build();
-        user.setKid(kid);
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-        TokenDTO tokenDTO = new TokenDTO(user);
-        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
-
-        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        CommonResponse result = userController.refreshUserToken("rT", response);
-
-        // then
-        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L);
-        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-    }
-
-    @Test
-    @DisplayName("타입 미선택 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-    public void testIfUserTokenRefreshSucceedThenReturnResult() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(null)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(null)
-            .refreshToken("token")
-            .build();
-
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-        TokenDTO tokenDTO = new TokenDTO(user);
-        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
-
-        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        CommonResponse result = userController.refreshUserToken("rT", response);
-
-        // then
-        LoginDTO loginDTO = new LoginDTO(null, "aT");
-        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-    }
-
-    @Test
-    @DisplayName("부모 유저 정보 조회 성공 시, 부모 결과 반환하는지 확인")
-    public void testIfGetParentInfoSucceedThenReturnResult() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(true)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(false)
-            .refreshToken("token")
-            .build();
-        Parent parent = Parent.builder()
-            .acceptedRequest(0L)
-            .totalRequest(0L)
-            .user(user)
-            .build();
-        user.setParent(parent);
-
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        CommonResponse result = userController.getUserInfo(user);
-
-        // then
-        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new ParentDTO(parent));
-        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
-    }
-
-    @Test
-    @DisplayName("자녀 유저 정보 조회 성공 시, 자녀 결과 반환하는지 확인")
-    public void testIfGetKidInfoSucceedThenReturnResult() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(true)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(true)
-            .refreshToken("token")
-            .build();
-        Kid kid = Kid.builder()
-            .savings(0L)
-            .achievedChallenge(0L)
-            .totalChallenge(0L)
-            .level(1L)
-            .user(user)
-            .build();
-        user.setKid(kid);
-
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        CommonResponse result = userController.getUserInfo(user);
-
-        // then
-        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new KidDTO(kid));
-        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
-    }
-
-    @Test
-    @DisplayName("유저 타입 선택 없이 유저 정보 조회 시, 에러 처리하는지 확인")
-    public void testIfGetUserInfoFailWithoutUserTypeThenThrowBadRequestException() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(null)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(null)
-            .refreshToken("token")
-            .build();
-        Kid kid = Kid.builder()
-            .savings(0L)
-            .achievedChallenge(0L)
-            .totalChallenge(0L)
-            .level(1L)
-            .user(user)
-            .build();
-        user.setKid(kid);
-
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        Mockito.when(mockUserRepository.findById(1L))
-            .thenReturn(Optional.ofNullable(user));
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        // then
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            userController.getUserInfo(user);
-        });
-    }
-
-    @Test
-    @DisplayName("유저 로그아웃 성공 시, null 반환하는지 확인")
-    public void testIfUserLogoutSucceedThenReturnResult() {
-        // given
-        User user = User.builder()
-            .id(1L)
-            .username("user1")
-            .isFemale(true)
-            .authenticationCode("code")
-            .provider("kakao")
-            .isKid(true)
-            .refreshToken("token")
-            .build();
-
-        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-
-        // when
-        UserServiceImpl userService = new UserServiceImpl(
-            mockUserRepository,
-            mockKidRepository,
-            mockParentRepository,
-            jwtTokenServiceImpl
-        );
-        UserController userController = new UserController(
-            userService
-        );
-
-        CommonResponse result = userController.patchUserLogout(user);
-
-        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-        user.setRefreshToken("");
-        user.setExpoToken("");
-        Assertions.assertEquals(user.getRefreshToken(), uCaptor.getValue().getRefreshToken());
-        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
-
-        // then
-        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
-    }
-}
+//package com.ceos.bankids.unit.controller;
+//
+//import com.ceos.bankids.config.CommonResponse;
+//import com.ceos.bankids.controller.UserController;
+//import com.ceos.bankids.controller.request.UserTypeRequest;
+//import com.ceos.bankids.domain.Kid;
+//import com.ceos.bankids.domain.Parent;
+//import com.ceos.bankids.domain.User;
+//import com.ceos.bankids.dto.KidDTO;
+//import com.ceos.bankids.dto.LoginDTO;
+//import com.ceos.bankids.dto.MyPageDTO;
+//import com.ceos.bankids.dto.ParentDTO;
+//import com.ceos.bankids.dto.TokenDTO;
+//import com.ceos.bankids.dto.UserDTO;
+//import com.ceos.bankids.exception.BadRequestException;
+//import com.ceos.bankids.repository.KidRepository;
+//import com.ceos.bankids.repository.ParentRepository;
+//import com.ceos.bankids.repository.UserRepository;
+//import com.ceos.bankids.service.JwtTokenServiceImpl;
+//import com.ceos.bankids.service.UserServiceImpl;
+//import java.util.Optional;
+//import javax.servlet.http.HttpServletResponse;
+//import org.junit.jupiter.api.Assertions;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.Mockito;
+//
+//public class UserControllerTest {
+//
+//    @Test
+//    @DisplayName("유저 타입 패치 성공시, 결과 반환 하는지 확인")
+//    public void testIfUserTypePatchSucceedReturnResult() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//        CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
+//
+//        // then
+//        user.setBirthday("19990521");
+//        user.setIsFemale(false);
+//        user.setIsKid(true);
+//        UserDTO userDTO = new UserDTO(user);
+//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("유저 정보 이미 있어 실패시, 에러 처리 되는지 확인")
+//    public void testIfUserTypePatchFailWhenAlreadyPatchedThrowBadRequestException() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(true)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(true)
+//            .refreshToken("token")
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            userController.patchUserType(user, userTypeRequest);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("body 없어서 패치 실패시, 에러 처리 되는지 확인")
+//    public void testIfUserTypePatchFailWithoutArgumentsThrowNullPointerException() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(NullPointerException.class, () -> {
+//            userController.patchUserType(user, null);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("인증 유저 없어서 패치 실패시, 에러 처리 되는지 확인")
+//    public void testIfUserTypePatchFailWithoutValidUserThrowBadRequestException() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(null));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            userController.patchUserType(user, userTypeRequest);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("100세 초과 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
+//    public void testIfUserTypePatchFailWithTooEarlyBirthdayThrowBadRequestException() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("18880818", false, true);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            userController.patchUserType(user, userTypeRequest);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("0세 미만 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
+//    public void testIfUserTypePatchFailWithTooLateBirthdayThrowBadRequestException() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("23450818", false, true);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            userController.patchUserType(user, userTypeRequest);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("자녀 지정시, 자녀 row 생성 확인")
+//    public void testIfKidInsertSucceedWhenUserTypePatchSucceed() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .build();
+//        Kid kid = Kid.builder()
+//            .savings(0L)
+//            .user(user)
+//            .level(1L)
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        Mockito.when(mockKidRepository.save(kid)).thenReturn(kid);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//        CommonResponse result = userController.patchUserType(user, userTypeRequest);
+//
+//        // then
+//        user.setBirthday("19990521");
+//        user.setIsFemale(false);
+//        user.setIsKid(true);
+//        UserDTO userDTO = new UserDTO(user);
+//
+//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+//        ArgumentCaptor<Kid> kCaptor = ArgumentCaptor.forClass(Kid.class);
+//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+//        Mockito.verify(mockKidRepository, Mockito.times(1)).save(kCaptor.capture());
+//
+//        Assertions.assertEquals(user, uCaptor.getValue());
+//        Assertions.assertEquals(kid, kCaptor.getValue());
+//
+//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("부모 지정시, 부모 row 생성 확인")
+//    public void testIfParentInsertSucceedWhenUserTypePatchSucceed() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .build();
+//        Parent parent = Parent.builder()
+//            .user(user)
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", true, false);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        Mockito.when(mockParentRepository.save(parent)).thenReturn(parent);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//        CommonResponse result = userController.patchUserType(user, userTypeRequest);
+//
+//        // then
+//        user.setBirthday("19990521");
+//        user.setIsFemale(true);
+//        user.setIsKid(false);
+//        UserDTO userDTO = new UserDTO(user);
+//
+//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+//        ArgumentCaptor<Parent> pCaptor = ArgumentCaptor.forClass(Parent.class);
+//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+//        Mockito.verify(mockParentRepository, Mockito.times(1)).save(pCaptor.capture());
+//
+//        Assertions.assertEquals(user, uCaptor.getValue());
+//        Assertions.assertEquals(parent, pCaptor.getValue());
+//
+//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("이미 타입을 선택한 유저 접근시, 에러 처리 되는지 확인")
+//    public void testIfUserTypePatchFailWhenAlreadyRegisteredThrowBadRequestException() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(true)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(false)
+//            .refreshToken("token")
+//            .build();
+//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(null));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            userController.patchUserType(user, userTypeRequest);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("부모 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+//    public void testIfParentTokenRefreshSucceedThenReturnResult() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(true)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(false)
+//            .refreshToken("token")
+//            .build();
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//        TokenDTO tokenDTO = new TokenDTO(user);
+//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
+//
+//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        CommonResponse result = userController.refreshUserToken("rT", response);
+//
+//        // then
+//        LoginDTO loginDTO = new LoginDTO(false, "aT");
+//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("자녀 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+//    public void testIfKidTokenRefreshSucceedThenReturnResult() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(true)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(true)
+//            .refreshToken("token")
+//            .build();
+//        Kid kid = Kid.builder()
+//            .level(1L)
+//            .user(user)
+//            .build();
+//        user.setKid(kid);
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//        TokenDTO tokenDTO = new TokenDTO(user);
+//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
+//
+//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        CommonResponse result = userController.refreshUserToken("rT", response);
+//
+//        // then
+//        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L);
+//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("타입 미선택 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+//    public void testIfUserTokenRefreshSucceedThenReturnResult() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(null)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(null)
+//            .refreshToken("token")
+//            .build();
+//
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//        TokenDTO tokenDTO = new TokenDTO(user);
+//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
+//
+//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        CommonResponse result = userController.refreshUserToken("rT", response);
+//
+//        // then
+//        LoginDTO loginDTO = new LoginDTO(null, "aT");
+//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("부모 유저 정보 조회 성공 시, 부모 결과 반환하는지 확인")
+//    public void testIfGetParentInfoSucceedThenReturnResult() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(true)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(false)
+//            .refreshToken("token")
+//            .build();
+//        Parent parent = Parent.builder()
+//            .acceptedRequest(0L)
+//            .totalRequest(0L)
+//            .user(user)
+//            .build();
+//        user.setParent(parent);
+//
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        CommonResponse result = userController.getUserInfo(user);
+//
+//        // then
+//        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new ParentDTO(parent));
+//        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("자녀 유저 정보 조회 성공 시, 자녀 결과 반환하는지 확인")
+//    public void testIfGetKidInfoSucceedThenReturnResult() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(true)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(true)
+//            .refreshToken("token")
+//            .build();
+//        Kid kid = Kid.builder()
+//            .savings(0L)
+//            .achievedChallenge(0L)
+//            .totalChallenge(0L)
+//            .level(1L)
+//            .user(user)
+//            .build();
+//        user.setKid(kid);
+//
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        CommonResponse result = userController.getUserInfo(user);
+//
+//        // then
+//        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new KidDTO(kid));
+//        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("유저 타입 선택 없이 유저 정보 조회 시, 에러 처리하는지 확인")
+//    public void testIfGetUserInfoFailWithoutUserTypeThenThrowBadRequestException() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(null)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(null)
+//            .refreshToken("token")
+//            .build();
+//        Kid kid = Kid.builder()
+//            .savings(0L)
+//            .achievedChallenge(0L)
+//            .totalChallenge(0L)
+//            .level(1L)
+//            .user(user)
+//            .build();
+//        user.setKid(kid);
+//
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        Mockito.when(mockUserRepository.findById(1L))
+//            .thenReturn(Optional.ofNullable(user));
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            userController.getUserInfo(user);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("유저 로그아웃 성공 시, null 반환하는지 확인")
+//    public void testIfUserLogoutSucceedThenReturnResult() {
+//        // given
+//        User user = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(true)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(true)
+//            .refreshToken("token")
+//            .build();
+//
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        UserController userController = new UserController(
+//            userService
+//        );
+//
+//        CommonResponse result = userController.patchUserLogout(user);
+//
+//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+//        user.setRefreshToken("");
+//        user.setExpoToken("");
+//        Assertions.assertEquals(user.getRefreshToken(), uCaptor.getValue().getRefreshToken());
+//        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
+//
+//        // then
+//        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+//    }
+//}

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -3,8 +3,11 @@ package com.ceos.bankids.unit.controller;
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.UserController;
 import com.ceos.bankids.controller.request.UserTypeRequest;
+import com.ceos.bankids.controller.request.WithdrawalRequest;
 import com.ceos.bankids.domain.Kid;
+import com.ceos.bankids.domain.KidBackup;
 import com.ceos.bankids.domain.Parent;
+import com.ceos.bankids.domain.ParentBackup;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.KidDTO;
 import com.ceos.bankids.dto.LoginDTO;
@@ -13,7 +16,11 @@ import com.ceos.bankids.dto.ParentDTO;
 import com.ceos.bankids.dto.TokenDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.repository.FamilyRepository;
+import com.ceos.bankids.repository.FamilyUserRepository;
+import com.ceos.bankids.repository.KidBackupRepository;
 import com.ceos.bankids.repository.KidRepository;
+import com.ceos.bankids.repository.ParentBackupRepository;
 import com.ceos.bankids.repository.ParentRepository;
 import com.ceos.bankids.repository.UserRepository;
 import com.ceos.bankids.service.ChallengeServiceImpl;
@@ -928,4 +935,542 @@ public class UserControllerTest {
         // then
         Assertions.assertEquals(CommonResponse.onSuccess(null), result);
     }
+
+    @Test
+    @DisplayName("가족 없는 부모 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfParentUserWithoutFamilyDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+        user1.setParent(parent);
+        ParentBackup parentBackup = ParentBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .acceptedRequest(user1.getParent().getAcceptedRequest())
+            .totalRequest(user1.getParent().getTotalRequest())
+            .build();
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+
+        ParentBackupRepository mockParentBackupRepository = Mockito.mock(
+            ParentBackupRepository.class);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = new ParentBackupServiceImpl(
+            mockParentBackupRepository);
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<ParentBackup> parentBackupCaptor = ArgumentCaptor.forClass(
+            ParentBackup.class);
+        Mockito.verify(mockParentBackupRepository, Mockito.times(1))
+            .save(parentBackupCaptor.capture());
+        Assertions.assertEquals(parentBackup, parentBackupCaptor.getValue());
+
+        ArgumentCaptor<Parent> parentCaptor = ArgumentCaptor.forClass(
+            Parent.class);
+        Mockito.verify(mockParentRepository, Mockito.times(1))
+            .delete(parentCaptor.capture());
+        Assertions.assertEquals(user1.getParent(), parentCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+    @Test
+    @DisplayName("가족 없는 자녀 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfKidUserWithoutFamilyDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        Kid kid = Kid.builder()
+            .id(1L)
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(0L)
+            .user(user1)
+            .build();
+        user1.setKid(kid);
+        KidBackup kidBackup = KidBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .savings(user1.getKid().getSavings())
+            .achievedChallenge(user1.getKid().getAchievedChallenge())
+            .totalChallenge(user1.getKid().getTotalChallenge())
+            .level(user1.getKid().getLevel())
+            .build();
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+
+        KidBackupRepository mockKidBackupRepository = Mockito.mock(
+            KidBackupRepository.class);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository);
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<KidBackup> kidBackupCaptor = ArgumentCaptor.forClass(
+            KidBackup.class);
+        Mockito.verify(mockKidBackupRepository, Mockito.times(1))
+            .save(kidBackupCaptor.capture());
+        Assertions.assertEquals(kidBackup, kidBackupCaptor.getValue());
+
+        ArgumentCaptor<Kid> kidCaptor = ArgumentCaptor.forClass(
+            Kid.class);
+        Mockito.verify(mockKidRepository, Mockito.times(1))
+            .delete(kidCaptor.capture());
+        Assertions.assertEquals(user1.getKid(), kidCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+//    @Test
+//    @DisplayName("부모 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+//    public void testIfParentUserDeleteAccountSucceedThenReturnResult() {
+//        // given
+//        User user1 = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .isFemale(true)
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .isKid(false)
+//            .refreshToken("token")
+//            .build();
+//        User user3 = User.builder()
+//            .id(3L)
+//            .username("user3")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .isKid(false)
+//            .isFemale(true)
+//            .build();
+//
+//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+//            .build();
+//        user1.setParent(parent);
+//
+//        Family family2 = Family.builder().id(2L).code("test").build();
+//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+//        List<FamilyUser> familyUserList = new ArrayList<>();
+//        familyUserList.add(familyUser3);
+//        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+//
+//        // mock
+//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+//            .thenReturn(Optional.ofNullable(familyUser1));
+//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+//        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
+//
+//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+//
+//        // when
+//        UserServiceImpl userService = new UserServiceImpl(
+//            mockUserRepository,
+//            mockKidRepository,
+//            mockParentRepository,
+//            jwtTokenServiceImpl
+//        );
+//        FamilyServiceImpl familyService = new FamilyServiceImpl(
+//            mockFamilyRepository,
+//            mockFamilyUserRepository
+//        );
+//        ChallengeServiceImpl challengeService = null;
+//        KidBackupServiceImpl kidBackupService = null;
+//        ParentBackupServiceImpl parentBackupService = null;
+//        KidServiceImpl kidService = null;
+//        ParentServiceImpl parentService = null;
+//
+//        UserController userController = new UserController(
+//            userService,
+//            familyService,
+//            challengeService,
+//            kidBackupService,
+//            parentBackupService,
+//            kidService,
+//            parentService
+//        );
+//
+//        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+//
+//        // then
+//        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+//    }
+
+//    @Test
+//    @DisplayName("자녀 가족 나가기 성공 시, 결과 반환 하는지 확인")
+//    public void testIfKidFamilyUserDeleteSucceedThenReturnResult() {
+//        // given
+//        User user1 = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .isKid(true)
+//            .isFemale(null)
+//            .build();
+//        User user3 = User.builder()
+//            .id(3L)
+//            .username("user3")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .isKid(false)
+//            .isFemale(true)
+//            .build();
+//
+//        Kid kid = Kid.builder()
+//            .id(1L)
+//            .savings(0L)
+//            .achievedChallenge(0L)
+//            .totalChallenge(0L)
+//            .level(1L)
+//            .user(user1)
+//            .build();
+//
+//        user1.setKid(kid);
+//
+//        Family family2 = Family.builder().id(2L).code("test").build();
+//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+//        List<FamilyUser> familyUserList = new ArrayList<>();
+//        familyUserList.add(familyUser3);
+//        FamilyRequest familyRequest = new FamilyRequest("test");
+//
+//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+//            .thenReturn(Optional.ofNullable(familyUser1));
+//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+//
+//        // when
+//        FamilyServiceImpl familyService = new FamilyServiceImpl(
+//            mockFamilyRepository,
+//            mockFamilyUserRepository
+//        );
+//        FamilyController familyController = new FamilyController(
+//            familyService,
+//            challengeService
+//        );
+//        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
+//
+//        // then
+//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
+//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+//
+//        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
+//            .map(FamilyUserDTO::new).collect(Collectors.toList());
+//        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
+//
+//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("유저 가족 나가기 성공 후 가족 없어 삭제 성공 시, 결과 반환 하는지 확인")
+//    public void testIfFamilyUserDeleteSucceedAndFamilyDeleteSucceedThenReturnResult() {
+//        // given
+//        User user1 = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .isKid(false)
+//            .isFemale(null)
+//            .build();
+//
+//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+//            .build();
+//
+//        user1.setParent(parent);
+//
+//        Family family2 = Family.builder().id(2L).code("test").build();
+//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+//        List<FamilyUser> familyUserList = new ArrayList<>();
+//        FamilyRequest familyRequest = new FamilyRequest("test");
+//
+//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+//            .thenReturn(Optional.ofNullable(familyUser1));
+//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+//
+//        // when
+//        FamilyServiceImpl familyService = new FamilyServiceImpl(
+//            mockFamilyRepository,
+//            mockFamilyUserRepository
+//        );
+//        FamilyController familyController = new FamilyController(
+//            familyService, challengeService
+//        );
+//        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
+//
+//        // then
+//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
+//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+//
+//        ArgumentCaptor<Family> fCaptor = ArgumentCaptor.forClass(Family.class);
+//        Mockito.verify(mockFamilyRepository, Mockito.times(1)).delete(fCaptor.capture());
+//        Assertions.assertEquals(family2, fCaptor.getValue());
+//
+//        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
+//            .map(FamilyUserDTO::new).collect(Collectors.toList());
+//        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
+//
+//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+//    }
+//
+//    @Test
+//    @DisplayName("유저가 가입된 가족이 없는 경우, 에러 처리 하는지 확인")
+//    public void testIfFamilyUserDeleteFailBecauseFamilyUserNotExistThenThrowBadRequestException() {
+//        // given
+//        User user1 = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .isKid(false)
+//            .isFemale(null)
+//            .build();
+//
+//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+//            .build();
+//
+//        user1.setParent(parent);
+//
+//        Family family2 = Family.builder().id(2L).code("test").build();
+//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+//        List<FamilyUser> familyUserList = new ArrayList<>();
+//        FamilyRequest familyRequest = new FamilyRequest("test");
+//
+//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+//            .thenReturn(Optional.ofNullable(null));
+//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+//
+//        // when
+//        FamilyServiceImpl familyService = new FamilyServiceImpl(
+//            mockFamilyRepository,
+//            mockFamilyUserRepository
+//        );
+//        FamilyController familyController = new FamilyController(
+//            familyService, challengeService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            familyController.deleteFamilyUser(user1, familyRequest);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("자녀가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
+//    public void testIfKidFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
+//        // given
+//        User user1 = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .isKid(true)
+//            .isFemale(null)
+//            .build();
+//
+//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+//            .build();
+//
+//        user1.setParent(parent);
+//
+//        Family family2 = Family.builder().id(2L).code("test").build();
+//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+//        List<FamilyUser> familyUserList = new ArrayList<>();
+//        FamilyRequest familyRequest = new FamilyRequest("code");
+//
+//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+//            .thenReturn(Optional.ofNullable(familyUser1));
+//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+//
+//        // when
+//        FamilyServiceImpl familyService = new FamilyServiceImpl(
+//            mockFamilyRepository,
+//            mockFamilyUserRepository
+//        );
+//        FamilyController familyController = new FamilyController(
+//            familyService, challengeService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            familyController.deleteFamilyUser(user1, familyRequest);
+//        });
+//    }
+//
+//    @Test
+//    @DisplayName("부모가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
+//    public void testIfParentFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
+//        // given
+//        User user1 = User.builder()
+//            .id(1L)
+//            .username("user1")
+//            .authenticationCode("code")
+//            .provider("kakao")
+//            .refreshToken("token")
+//            .isKid(false)
+//            .isFemale(null)
+//            .build();
+//
+//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+//            .build();
+//
+//        user1.setParent(parent);
+//
+//        Family family2 = Family.builder().id(2L).code("test").build();
+//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+//        List<FamilyUser> familyUserList = new ArrayList<>();
+//        FamilyRequest familyRequest = new FamilyRequest("code");
+//
+//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+//            .thenReturn(Optional.ofNullable(familyUser1));
+//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+//
+//        // when
+//        FamilyServiceImpl familyService = new FamilyServiceImpl(
+//            mockFamilyRepository,
+//            mockFamilyUserRepository
+//        );
+//        FamilyController familyController = new FamilyController(
+//            familyService, challengeService
+//        );
+//
+//        // then
+//        Assertions.assertThrows(BadRequestException.class, () -> {
+//            familyController.deleteFamilyUser(user1, familyRequest);
+//        });
+//    }
+
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -1,719 +1,931 @@
-//package com.ceos.bankids.unit.controller;
-//
-//import com.ceos.bankids.config.CommonResponse;
-//import com.ceos.bankids.controller.UserController;
-//import com.ceos.bankids.controller.request.UserTypeRequest;
-//import com.ceos.bankids.domain.Kid;
-//import com.ceos.bankids.domain.Parent;
-//import com.ceos.bankids.domain.User;
-//import com.ceos.bankids.dto.KidDTO;
-//import com.ceos.bankids.dto.LoginDTO;
-//import com.ceos.bankids.dto.MyPageDTO;
-//import com.ceos.bankids.dto.ParentDTO;
-//import com.ceos.bankids.dto.TokenDTO;
-//import com.ceos.bankids.dto.UserDTO;
-//import com.ceos.bankids.exception.BadRequestException;
-//import com.ceos.bankids.repository.KidRepository;
-//import com.ceos.bankids.repository.ParentRepository;
-//import com.ceos.bankids.repository.UserRepository;
-//import com.ceos.bankids.service.JwtTokenServiceImpl;
-//import com.ceos.bankids.service.UserServiceImpl;
-//import java.util.Optional;
-//import javax.servlet.http.HttpServletResponse;
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.Mockito;
-//
-//public class UserControllerTest {
-//
-//    @Test
-//    @DisplayName("유저 타입 패치 성공시, 결과 반환 하는지 확인")
-//    public void testIfUserTypePatchSucceedReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//        CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
-//
-//        // then
-//        user.setBirthday("19990521");
-//        user.setIsFemale(false);
-//        user.setIsKid(true);
-//        UserDTO userDTO = new UserDTO(user);
-//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 정보 이미 있어 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWhenAlreadyPatchedThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("body 없어서 패치 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWithoutArgumentsThrowNullPointerException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(NullPointerException.class, () -> {
-//            userController.patchUserType(user, null);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("인증 유저 없어서 패치 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWithoutValidUserThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("100세 초과 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWithTooEarlyBirthdayThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("18880818", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("0세 미만 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWithTooLateBirthdayThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("23450818", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("자녀 지정시, 자녀 row 생성 확인")
-//    public void testIfKidInsertSucceedWhenUserTypePatchSucceed() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        Kid kid = Kid.builder()
-//            .savings(0L)
-//            .user(user)
-//            .level(1L)
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        Mockito.when(mockKidRepository.save(kid)).thenReturn(kid);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//        CommonResponse result = userController.patchUserType(user, userTypeRequest);
-//
-//        // then
-//        user.setBirthday("19990521");
-//        user.setIsFemale(false);
-//        user.setIsKid(true);
-//        UserDTO userDTO = new UserDTO(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        ArgumentCaptor<Kid> kCaptor = ArgumentCaptor.forClass(Kid.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Mockito.verify(mockKidRepository, Mockito.times(1)).save(kCaptor.capture());
-//
-//        Assertions.assertEquals(user, uCaptor.getValue());
-//        Assertions.assertEquals(kid, kCaptor.getValue());
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("부모 지정시, 부모 row 생성 확인")
-//    public void testIfParentInsertSucceedWhenUserTypePatchSucceed() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        Parent parent = Parent.builder()
-//            .user(user)
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", true, false);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        Mockito.when(mockParentRepository.save(parent)).thenReturn(parent);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//        CommonResponse result = userController.patchUserType(user, userTypeRequest);
-//
-//        // then
-//        user.setBirthday("19990521");
-//        user.setIsFemale(true);
-//        user.setIsKid(false);
-//        UserDTO userDTO = new UserDTO(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        ArgumentCaptor<Parent> pCaptor = ArgumentCaptor.forClass(Parent.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Mockito.verify(mockParentRepository, Mockito.times(1)).save(pCaptor.capture());
-//
-//        Assertions.assertEquals(user, uCaptor.getValue());
-//        Assertions.assertEquals(parent, pCaptor.getValue());
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("이미 타입을 선택한 유저 접근시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWhenAlreadyRegisteredThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("부모 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-//    public void testIfParentTokenRefreshSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        TokenDTO tokenDTO = new TokenDTO(user);
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
-//
-//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        CommonResponse result = userController.refreshUserToken("rT", response);
-//
-//        // then
-//        LoginDTO loginDTO = new LoginDTO(false, "aT");
-//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("자녀 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-//    public void testIfKidTokenRefreshSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//        Kid kid = Kid.builder()
-//            .level(1L)
-//            .user(user)
-//            .build();
-//        user.setKid(kid);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        TokenDTO tokenDTO = new TokenDTO(user);
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
-//
-//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        CommonResponse result = userController.refreshUserToken("rT", response);
-//
-//        // then
-//        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L);
-//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("타입 미선택 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-//    public void testIfUserTokenRefreshSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(null)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(null)
-//            .refreshToken("token")
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        TokenDTO tokenDTO = new TokenDTO(user);
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
-//
-//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        CommonResponse result = userController.refreshUserToken("rT", response);
-//
-//        // then
-//        LoginDTO loginDTO = new LoginDTO(null, "aT");
-//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("부모 유저 정보 조회 성공 시, 부모 결과 반환하는지 확인")
-//    public void testIfGetParentInfoSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//        Parent parent = Parent.builder()
-//            .acceptedRequest(0L)
-//            .totalRequest(0L)
-//            .user(user)
-//            .build();
-//        user.setParent(parent);
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        CommonResponse result = userController.getUserInfo(user);
-//
-//        // then
-//        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new ParentDTO(parent));
-//        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("자녀 유저 정보 조회 성공 시, 자녀 결과 반환하는지 확인")
-//    public void testIfGetKidInfoSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//        Kid kid = Kid.builder()
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(1L)
-//            .user(user)
-//            .build();
-//        user.setKid(kid);
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        CommonResponse result = userController.getUserInfo(user);
-//
-//        // then
-//        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new KidDTO(kid));
-//        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 타입 선택 없이 유저 정보 조회 시, 에러 처리하는지 확인")
-//    public void testIfGetUserInfoFailWithoutUserTypeThenThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(null)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(null)
-//            .refreshToken("token")
-//            .build();
-//        Kid kid = Kid.builder()
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(1L)
-//            .user(user)
-//            .build();
-//        user.setKid(kid);
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.getUserInfo(user);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("유저 로그아웃 성공 시, null 반환하는지 확인")
-//    public void testIfUserLogoutSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        UserController userController = new UserController(
-//            userService
-//        );
-//
-//        CommonResponse result = userController.patchUserLogout(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        user.setRefreshToken("");
-//        user.setExpoToken("");
-//        Assertions.assertEquals(user.getRefreshToken(), uCaptor.getValue().getRefreshToken());
-//        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
-//    }
-//}
+package com.ceos.bankids.unit.controller;
+
+import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.UserController;
+import com.ceos.bankids.controller.request.UserTypeRequest;
+import com.ceos.bankids.domain.Kid;
+import com.ceos.bankids.domain.Parent;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.KidDTO;
+import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.MyPageDTO;
+import com.ceos.bankids.dto.ParentDTO;
+import com.ceos.bankids.dto.TokenDTO;
+import com.ceos.bankids.dto.UserDTO;
+import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.repository.KidRepository;
+import com.ceos.bankids.repository.ParentRepository;
+import com.ceos.bankids.repository.UserRepository;
+import com.ceos.bankids.service.ChallengeServiceImpl;
+import com.ceos.bankids.service.FamilyServiceImpl;
+import com.ceos.bankids.service.JwtTokenServiceImpl;
+import com.ceos.bankids.service.KidBackupServiceImpl;
+import com.ceos.bankids.service.KidServiceImpl;
+import com.ceos.bankids.service.ParentBackupServiceImpl;
+import com.ceos.bankids.service.ParentServiceImpl;
+import com.ceos.bankids.service.UserServiceImpl;
+import java.util.Optional;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class UserControllerTest {
+
+    @Test
+    @DisplayName("유저 타입 패치 성공시, 결과 반환 하는지 확인")
+    public void testIfUserTypePatchSucceedReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+        CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
+
+        // then
+        user.setBirthday("19990521");
+        user.setIsFemale(false);
+        user.setIsKid(true);
+        UserDTO userDTO = new UserDTO(user);
+        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 정보 이미 있어 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWhenAlreadyPatchedThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("body 없어서 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithoutArgumentsThrowNullPointerException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        // then
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            userController.patchUserType(user, null);
+        });
+    }
+
+    @Test
+    @DisplayName("인증 유저 없어서 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithoutValidUserThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(null));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("100세 초과 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithTooEarlyBirthdayThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("18880818", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("0세 미만 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithTooLateBirthdayThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("23450818", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("자녀 지정시, 자녀 row 생성 확인")
+    public void testIfKidInsertSucceedWhenUserTypePatchSucceed() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .savings(0L)
+            .user(user)
+            .level(1L)
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        Mockito.when(mockKidRepository.save(kid)).thenReturn(kid);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+        CommonResponse result = userController.patchUserType(user, userTypeRequest);
+
+        // then
+        user.setBirthday("19990521");
+        user.setIsFemale(false);
+        user.setIsKid(true);
+        UserDTO userDTO = new UserDTO(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        ArgumentCaptor<Kid> kCaptor = ArgumentCaptor.forClass(Kid.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Mockito.verify(mockKidRepository, Mockito.times(1)).save(kCaptor.capture());
+
+        Assertions.assertEquals(user, uCaptor.getValue());
+        Assertions.assertEquals(kid, kCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+    }
+
+    @Test
+    @DisplayName("부모 지정시, 부모 row 생성 확인")
+    public void testIfParentInsertSucceedWhenUserTypePatchSucceed() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        Parent parent = Parent.builder()
+            .user(user)
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", true, false);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        Mockito.when(mockParentRepository.save(parent)).thenReturn(parent);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+        CommonResponse result = userController.patchUserType(user, userTypeRequest);
+
+        // then
+        user.setBirthday("19990521");
+        user.setIsFemale(true);
+        user.setIsKid(false);
+        UserDTO userDTO = new UserDTO(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        ArgumentCaptor<Parent> pCaptor = ArgumentCaptor.forClass(Parent.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Mockito.verify(mockParentRepository, Mockito.times(1)).save(pCaptor.capture());
+
+        Assertions.assertEquals(user, uCaptor.getValue());
+        Assertions.assertEquals(parent, pCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+    }
+
+    @Test
+    @DisplayName("이미 타입을 선택한 유저 접근시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWhenAlreadyRegisteredThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(null));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("부모 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+    public void testIfParentTokenRefreshSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        TokenDTO tokenDTO = new TokenDTO(user);
+        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+        CommonResponse result = userController.refreshUserToken("rT", response);
+
+        // then
+        LoginDTO loginDTO = new LoginDTO(false, "aT");
+        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+    }
+
+    @Test
+    @DisplayName("자녀 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+    public void testIfKidTokenRefreshSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        TokenDTO tokenDTO = new TokenDTO(user);
+        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        CommonResponse result = userController.refreshUserToken("rT", response);
+
+        // then
+        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L);
+        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+    }
+
+    @Test
+    @DisplayName("타입 미선택 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+    public void testIfUserTokenRefreshSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(null)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("token")
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        TokenDTO tokenDTO = new TokenDTO(user);
+        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn("1");
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        CommonResponse result = userController.refreshUserToken("rT", response);
+
+        // then
+        LoginDTO loginDTO = new LoginDTO(null, "aT");
+        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+    }
+
+    @Test
+    @DisplayName("부모 유저 정보 조회 성공 시, 부모 결과 반환하는지 확인")
+    public void testIfGetParentInfoSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+        Parent parent = Parent.builder()
+            .acceptedRequest(0L)
+            .totalRequest(0L)
+            .user(user)
+            .build();
+        user.setParent(parent);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        CommonResponse result = userController.getUserInfo(user);
+
+        // then
+        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new ParentDTO(parent));
+        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
+    }
+
+    @Test
+    @DisplayName("자녀 유저 정보 조회 성공 시, 자녀 결과 반환하는지 확인")
+    public void testIfGetKidInfoSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        CommonResponse result = userController.getUserInfo(user);
+
+        // then
+        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new KidDTO(kid));
+        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 타입 선택 없이 유저 정보 조회 시, 에러 처리하는지 확인")
+    public void testIfGetUserInfoFailWithoutUserTypeThenThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(null)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.getUserInfo(user);
+        });
+    }
+
+    @Test
+    @DisplayName("유저 로그아웃 성공 시, null 반환하는지 확인")
+    public void testIfUserLogoutSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService
+        );
+
+        CommonResponse result = userController.patchUserLogout(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        user.setRefreshToken("");
+        user.setExpoToken("");
+        Assertions.assertEquals(user.getRefreshToken(), uCaptor.getValue().getRefreshToken());
+        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+    }
+}

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -2,8 +2,11 @@ package com.ceos.bankids.unit.controller;
 
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.UserController;
+import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.controller.request.WithdrawalRequest;
+import com.ceos.bankids.domain.Family;
+import com.ceos.bankids.domain.FamilyUser;
 import com.ceos.bankids.domain.Kid;
 import com.ceos.bankids.domain.KidBackup;
 import com.ceos.bankids.domain.Parent;
@@ -30,7 +33,10 @@ import com.ceos.bankids.service.KidBackupServiceImpl;
 import com.ceos.bankids.service.KidServiceImpl;
 import com.ceos.bankids.service.ParentBackupServiceImpl;
 import com.ceos.bankids.service.ParentServiceImpl;
+import com.ceos.bankids.service.SlackServiceImpl;
 import com.ceos.bankids.service.UserServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Assertions;
@@ -73,6 +79,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -81,7 +88,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
         CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
 
@@ -127,6 +135,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -135,7 +144,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         // then
@@ -176,6 +186,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -184,7 +195,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         // then
@@ -225,6 +237,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -233,7 +246,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         // then
@@ -274,6 +288,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -282,7 +297,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         // then
@@ -323,6 +339,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -331,7 +348,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
         // then
         Assertions.assertThrows(BadRequestException.class, () -> {
@@ -378,6 +396,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -386,7 +405,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
         CommonResponse result = userController.patchUserType(user, userTypeRequest);
 
@@ -444,6 +464,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -452,7 +473,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
         CommonResponse result = userController.patchUserType(user, userTypeRequest);
 
@@ -507,6 +529,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -515,7 +538,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         // then
@@ -564,6 +588,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -572,7 +597,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
         CommonResponse result = userController.refreshUserToken("rT", response);
 
@@ -626,6 +652,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -634,7 +661,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         CommonResponse result = userController.refreshUserToken("rT", response);
@@ -685,6 +713,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -693,7 +722,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         CommonResponse result = userController.refreshUserToken("rT", response);
@@ -743,6 +773,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -751,7 +782,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         CommonResponse result = userController.getUserInfo(user);
@@ -803,6 +835,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -811,7 +844,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         CommonResponse result = userController.getUserInfo(user);
@@ -863,6 +897,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -871,7 +906,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         // then
@@ -912,6 +948,7 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
 
         UserController userController = new UserController(
             userService,
@@ -920,7 +957,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         CommonResponse result = userController.patchUserLogout(user);
@@ -993,6 +1031,10 @@ public class UserControllerTest {
             mockParentBackupRepository);
         KidServiceImpl kidService = null;
         ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("ParentBackup ", parentBackup.getId(),
+                withdrawalRequest.getMessage());
 
         UserController userController = new UserController(
             userService,
@@ -1001,7 +1043,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
@@ -1070,7 +1113,6 @@ public class UserControllerTest {
 
         KidBackupRepository mockKidBackupRepository = Mockito.mock(
             KidBackupRepository.class);
-
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
@@ -1092,6 +1134,10 @@ public class UserControllerTest {
         ParentBackupServiceImpl parentBackupService = null;
         KidServiceImpl kidService = new KidServiceImpl(mockKidRepository);
         ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("KidBackup ", kidBackup.getId(),
+                withdrawalRequest.getMessage());
 
         UserController userController = new UserController(
             userService,
@@ -1100,7 +1146,8 @@ public class UserControllerTest {
             kidBackupService,
             parentBackupService,
             kidService,
-            parentService
+            parentService,
+            slackService
         );
 
         CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
@@ -1127,350 +1174,238 @@ public class UserControllerTest {
         Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
     }
 
-//    @Test
-//    @DisplayName("부모 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
-//    public void testIfParentUserDeleteAccountSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser3);
-//        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
-//
-//        // mock
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(
-//            mockUserRepository,
-//            mockKidRepository,
-//            mockParentRepository,
-//            jwtTokenServiceImpl
-//        );
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository,
-//            mockFamilyUserRepository
-//        );
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService
-//        );
-//
-//        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
-//    }
+    @Test
+    @DisplayName("가족 있는 부모 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfParentUserWithFamilyDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
 
-//    @Test
-//    @DisplayName("자녀 가족 나가기 성공 시, 결과 반환 하는지 확인")
-//    public void testIfKidFamilyUserDeleteSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(null)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//
-//        Kid kid = Kid.builder()
-//            .id(1L)
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(1L)
-//            .user(user1)
-//            .build();
-//
-//        user1.setKid(kid);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser3);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository,
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            challengeService
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-//            .map(FamilyUserDTO::new).collect(Collectors.toList());
-//        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 가족 나가기 성공 후 가족 없어 삭제 성공 시, 결과 반환 하는지 확인")
-//    public void testIfFamilyUserDeleteSucceedAndFamilyDeleteSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(null)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository,
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService, challengeService
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        ArgumentCaptor<Family> fCaptor = ArgumentCaptor.forClass(Family.class);
-//        Mockito.verify(mockFamilyRepository, Mockito.times(1)).delete(fCaptor.capture());
-//        Assertions.assertEquals(family2, fCaptor.getValue());
-//
-//        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-//            .map(FamilyUserDTO::new).collect(Collectors.toList());
-//        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저가 가입된 가족이 없는 경우, 에러 처리 하는지 확인")
-//    public void testIfFamilyUserDeleteFailBecauseFamilyUserNotExistThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(null)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository,
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService, challengeService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.deleteFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("자녀가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
-//    public void testIfKidFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(null)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("code");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository,
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService, challengeService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.deleteFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("부모가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
-//    public void testIfParentFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(null)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("code");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository,
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService, challengeService
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.deleteFamilyUser(user1, familyRequest);
-//        });
-//    }
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+        user1.setParent(parent);
+        ParentBackup parentBackup = ParentBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .acceptedRequest(user1.getParent().getAcceptedRequest())
+            .totalRequest(user1.getParent().getTotalRequest())
+            .build();
 
+        Family family = Family.builder().id(1L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        FamilyRequest familyRequest = new FamilyRequest("test");
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(familyUser1));
+
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+
+        ParentBackupRepository mockParentBackupRepository = Mockito.mock(
+            ParentBackupRepository.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = new ParentBackupServiceImpl(
+            mockParentBackupRepository);
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("ParentBackup ", parentBackup.getId(),
+                withdrawalRequest.getMessage());
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService
+        );
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<FamilyUser> familyUserCaptor = ArgumentCaptor.forClass(
+            FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1))
+            .delete(familyUserCaptor.capture());
+        Assertions.assertEquals(familyUser1, familyUserCaptor.getValue());
+
+        ArgumentCaptor<Family> familyCaptor = ArgumentCaptor.forClass(
+            Family.class);
+        Mockito.verify(mockFamilyRepository, Mockito.times(1))
+            .delete(familyCaptor.capture());
+        Assertions.assertEquals(family, familyCaptor.getValue());
+
+        ArgumentCaptor<ParentBackup> parentBackupCaptor = ArgumentCaptor.forClass(
+            ParentBackup.class);
+        Mockito.verify(mockParentBackupRepository, Mockito.times(1))
+            .save(parentBackupCaptor.capture());
+        Assertions.assertEquals(parentBackup, parentBackupCaptor.getValue());
+
+        ArgumentCaptor<Parent> parentCaptor = ArgumentCaptor.forClass(
+            Parent.class);
+        Mockito.verify(mockParentRepository, Mockito.times(1))
+            .delete(parentCaptor.capture());
+        Assertions.assertEquals(user1.getParent(), parentCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+    @Test
+    @DisplayName("가족 있는 자녀 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfKidUserWithFamilyDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        Kid kid = Kid.builder()
+            .id(1L)
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(0L)
+            .user(user1)
+            .build();
+        user1.setKid(kid);
+        KidBackup kidBackup = KidBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .savings(user1.getKid().getSavings())
+            .achievedChallenge(user1.getKid().getAchievedChallenge())
+            .totalChallenge(user1.getKid().getTotalChallenge())
+            .level(user1.getKid().getLevel())
+            .build();
+
+        Family family = Family.builder().id(1L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        FamilyRequest familyRequest = new FamilyRequest("test");
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+
+        KidBackupRepository mockKidBackupRepository = Mockito.mock(
+            KidBackupRepository.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = new FamilyServiceImpl(
+            mockFamilyRepository,
+            mockFamilyUserRepository
+        );
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository);
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("KidBackup ", kidBackup.getId(),
+                withdrawalRequest.getMessage());
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService
+        );
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<FamilyUser> familyUserCaptor = ArgumentCaptor.forClass(
+            FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1))
+            .delete(familyUserCaptor.capture());
+        Assertions.assertEquals(familyUser1, familyUserCaptor.getValue());
+
+        ArgumentCaptor<Family> familyCaptor = ArgumentCaptor.forClass(
+            Family.class);
+        Mockito.verify(mockFamilyRepository, Mockito.times(1))
+            .delete(familyCaptor.capture());
+        Assertions.assertEquals(family, familyCaptor.getValue());
+
+        ArgumentCaptor<KidBackup> kidBackupCaptor = ArgumentCaptor.forClass(
+            KidBackup.class);
+        Mockito.verify(mockKidBackupRepository, Mockito.times(1))
+            .save(kidBackupCaptor.capture());
+        Assertions.assertEquals(kidBackup, kidBackupCaptor.getValue());
+
+        ArgumentCaptor<Kid> kidCaptor = ArgumentCaptor.forClass(
+            Kid.class);
+        Mockito.verify(mockKidRepository, Mockito.times(1))
+            .delete(kidCaptor.capture());
+        Assertions.assertEquals(user1.getKid(), kidCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
 }


### PR DESCRIPTION
## 📝 PR Summary
- 유저 탈퇴 로직 작성했습니다.
- 챌린지 관련된 로직은 가족 나가기 기능과 동일하게 작성했습니다.
- 추가로 유저 개인 정보를 제외한 데이터는 부모/자녀로 나누어서 백업 테이블에 백업했습니다.
- 슬랙으로 탈퇴 사유 전송합니다. 
- 테스트 코드를 백개 넘겼는데 PR도 마침 백번째네요...
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/deleteAccount
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] 챌린지 관련 삭제 로직
- [x] 가족 나가기
- [x] 유저 개인정보 제외 활동 내용 백업
- [x] 탈퇴 사유 웹훅
- [x] 유저 삭제
- [x] 테스트 코드
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#169 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
