### PR TITLE
feat: 애플 로그인 및 연동 해제, 엑스포 토큰

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/AppleController.java
+++ b/src/main/java/com/ceos/bankids/controller/AppleController.java
@@ -49,7 +49,7 @@ public class AppleController {
         AppleTokenDTO appleTokenDTO = appleService.getAppleAccessToken(appleRequest);
 
         LoginDTO loginDTO = userService.loginWithAppleAuthenticationCode(
-            appleSubjectDTO.getAuthenticationCode(), appleRequest, response);
+            appleSubjectDTO.getAuthenticationCode(), appleRequest);
 
         response.sendRedirect(
             "https://bankidz.com/auth/apple/callback?isKid=" + loginDTO.getIsKid() + "&level="

--- a/src/main/java/com/ceos/bankids/controller/AppleController.java
+++ b/src/main/java/com/ceos/bankids/controller/AppleController.java
@@ -4,9 +4,10 @@ import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.AppleRequest;
 import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.oauth.AppleKeyListDTO;
+import com.ceos.bankids.dto.oauth.AppleSubjectDTO;
 import com.ceos.bankids.dto.oauth.AppleTokenDTO;
 import com.ceos.bankids.service.AppleServiceImpl;
-import io.jsonwebtoken.Claims;
+import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class AppleController {
 
     private final AppleServiceImpl appleService;
+    private final UserServiceImpl userService;
 
     @ApiOperation(value = "애플 로그인")
     @PostMapping(value = "/login", produces = "application/json; charset=utf-8", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
@@ -41,12 +43,13 @@ public class AppleController {
 
         AppleKeyListDTO appleKeyListDTO = appleService.getAppleIdentityToken();
 
-        Claims claims = appleService.verifyIdentityToken(appleRequest, appleKeyListDTO);
+        AppleSubjectDTO appleSubjectDTO = appleService.verifyIdentityToken(appleRequest,
+            appleKeyListDTO);
 
         AppleTokenDTO appleTokenDTO = appleService.getAppleAccessToken(appleRequest);
 
-        LoginDTO loginDTO = appleService.loginWithAuthenticationCode(claims, appleRequest,
-            response);
+        LoginDTO loginDTO = userService.loginWithAppleAuthenticationCode(
+            appleSubjectDTO.getAuthenticationCode(), appleRequest, response);
 
         response.sendRedirect(
             "https://bankidz.com/auth/apple/callback?isKid=" + loginDTO.getIsKid() + "&level="
@@ -62,7 +65,8 @@ public class AppleController {
         log.info("api = 애플 연동해제");
         AppleKeyListDTO appleKeyListDTO = appleService.getAppleIdentityToken();
 
-        Claims claims = appleService.verifyIdentityToken(appleRequest, appleKeyListDTO);
+        AppleSubjectDTO appleSubjectDTO = appleService.verifyIdentityToken(appleRequest,
+            appleKeyListDTO);
 
         AppleTokenDTO appleTokenDTO = appleService.getAppleAccessToken(appleRequest);
 

--- a/src/main/java/com/ceos/bankids/controller/AppleController.java
+++ b/src/main/java/com/ceos/bankids/controller/AppleController.java
@@ -48,7 +48,9 @@ public class AppleController {
         LoginDTO loginDTO = appleService.loginWithAuthenticationCode(claims, appleRequest,
             response);
 
-        response.sendRedirect("https://bankidz.com/auth/apple/callback");
+        response.sendRedirect(
+            "https://bankidz.com/auth/apple/callback?isKid=" + loginDTO.getIsKid() + "&level="
+                + loginDTO.getLevel() + "&accessToken=" + loginDTO.getAccessToken());
     }
 
     @ApiOperation(value = "애플 연동해제")

--- a/src/main/java/com/ceos/bankids/controller/AppleController.java
+++ b/src/main/java/com/ceos/bankids/controller/AppleController.java
@@ -1,6 +1,5 @@
 package com.ceos.bankids.controller;
 
-import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.AppleRequest;
 import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.oauth.AppleKeyListDTO;
@@ -11,13 +10,11 @@ import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,6 +35,7 @@ public class AppleController {
     public void postAppleLogin(
         @RequestBody MultiValueMap<String, String> formData, HttpServletResponse response)
         throws IOException {
+
         log.info("api = 애플 로그인");
         AppleRequest appleRequest = appleService.getAppleRequest(formData);
 
@@ -57,12 +55,15 @@ public class AppleController {
     }
 
     @ApiOperation(value = "애플 연동해제")
-    @DeleteMapping(value = "/login", produces = "application/json; charset=utf-8")
+    @PostMapping(value = "/revoke", produces = "application/json; charset=utf-8")
     @ResponseBody
-    public CommonResponse<Object> deleteAppleLogin(@Valid @RequestBody AppleRequest appleRequest,
-        HttpServletResponse response) {
+    public void deleteAppleLogin(
+        @RequestBody MultiValueMap<String, String> formData, HttpServletResponse response)
+        throws IOException {
 
         log.info("api = 애플 연동해제");
+        AppleRequest appleRequest = appleService.getAppleRequest(formData);
+
         AppleKeyListDTO appleKeyListDTO = appleService.getAppleIdentityToken();
 
         AppleSubjectDTO appleSubjectDTO = appleService.verifyIdentityToken(appleRequest,
@@ -72,7 +73,6 @@ public class AppleController {
 
         Object appleResponse = appleService.revokeAppleAccount(appleTokenDTO);
 
-        return CommonResponse.onSuccess(appleResponse);
+        response.sendRedirect("https://bankidz.com/auth/apple/callback");
     }
-
 }

--- a/src/main/java/com/ceos/bankids/controller/AppleController.java
+++ b/src/main/java/com/ceos/bankids/controller/AppleController.java
@@ -51,7 +51,8 @@ public class AppleController {
 
         response.sendRedirect(
             "https://bankidz.com/auth/apple/callback?isKid=" + loginDTO.getIsKid() + "&level="
-                + loginDTO.getLevel() + "&accessToken=" + loginDTO.getAccessToken());
+                + loginDTO.getLevel() + "&accessToken=" + loginDTO.getAccessToken() + "&provider="
+                + loginDTO.getProvider());
     }
 
     @ApiOperation(value = "애플 연동해제")

--- a/src/main/java/com/ceos/bankids/controller/KakaoController.java
+++ b/src/main/java/com/ceos/bankids/controller/KakaoController.java
@@ -39,7 +39,7 @@ public class KakaoController {
 
         KakaoUserDTO kakaoUserDTO = kakaoService.getKakaoUserCode(kakaoTokenDTO);
 
-        LoginDTO loginDTO = userService.loginWithKakaoAuthenticationCode(kakaoUserDTO, response);
+        LoginDTO loginDTO = userService.loginWithKakaoAuthenticationCode(kakaoUserDTO);
 
         return CommonResponse.onSuccess(loginDTO);
     }

--- a/src/main/java/com/ceos/bankids/controller/KakaoController.java
+++ b/src/main/java/com/ceos/bankids/controller/KakaoController.java
@@ -6,6 +6,7 @@ import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.oauth.KakaoTokenDTO;
 import com.ceos.bankids.dto.oauth.KakaoUserDTO;
 import com.ceos.bankids.service.KakaoServiceImpl;
+import com.ceos.bankids.service.UserServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class KakaoController {
 
     private final KakaoServiceImpl kakaoService;
+    private final UserServiceImpl userService;
 
 
     @ApiOperation(value = "카카오 로그인")
@@ -37,7 +39,7 @@ public class KakaoController {
 
         KakaoUserDTO kakaoUserDTO = kakaoService.getKakaoUserCode(kakaoTokenDTO);
 
-        LoginDTO loginDTO = kakaoService.loginWithAuthenticationCode(kakaoUserDTO, response);
+        LoginDTO loginDTO = userService.loginWithKakaoAuthenticationCode(kakaoUserDTO, response);
 
         return CommonResponse.onSuccess(loginDTO);
     }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -70,8 +70,9 @@ public class UserController {
 
         log.info("api = 토큰 리프레시");
         User user = userService.getUserByRefreshToken(refreshToken);
-        LoginDTO loginDTO = userService.issueNewTokens(user, response);
+        LoginDTO loginDTO = userService.issueNewTokens(user);
 
+        userService.setNewCookie(user, response);
         return CommonResponse.onSuccess(loginDTO);
     }
 

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -70,7 +70,7 @@ public class UserController {
 
         log.info("api = 토큰 리프레시");
         User user = userService.getUserByRefreshToken(refreshToken);
-        LoginDTO loginDTO = userService.issueNewTokens(user);
+        LoginDTO loginDTO = userService.issueNewTokens(user, user.getProvider());
 
         userService.setNewCookie(user, response);
         return CommonResponse.onSuccess(loginDTO);

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -1,8 +1,8 @@
 package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
-import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.controller.request.ExpoRequest;
+import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.controller.request.WithdrawalRequest;
 import com.ceos.bankids.domain.User;
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -139,12 +138,13 @@ public class UserController {
     @ApiOperation(value = "유저 엑스포 토큰 등록")
     @PatchMapping(value = "/expo", produces = "application/json; charset=utf-8")
     @ResponseBody
-    public void patchExpoToken(@AuthenticationPrincipal User authUser,
+    public CommonResponse<UserDTO> patchExpoToken(@AuthenticationPrincipal User authUser,
         @Valid @RequestBody ExpoRequest expoRequest, HttpServletResponse response) {
 
         log.info("api = 유저 엑스포 토큰 등록, user = {}", authUser.getUsername());
         User user = userService.updateUserExpoToken(authUser, expoRequest);
 
         userService.setNewCookie(user, response);
+        return CommonResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.request.ExpoRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.LoginDTO;
@@ -74,5 +75,17 @@ public class UserController {
         UserDTO userDTO = userService.updateUserLogout(authUser);
 
         return CommonResponse.onSuccess(userDTO);
+    }
+
+    @ApiOperation(value = "유저 엑스포 토큰 등록")
+    @PatchMapping(value = "/expo", produces = "application/json; charset=utf-8")
+    @ResponseBody
+    public void patchExpoToken(@AuthenticationPrincipal User authUser,
+        @Valid @RequestBody ExpoRequest expoRequest, HttpServletResponse response) {
+
+        log.info("api = 유저 엑스포 토큰 등록, user = {}", authUser.getUsername());
+        User user = userService.updateUserExpoToken(authUser, expoRequest);
+
+        userService.setNewCookie(user, response);
     }
 }

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -51,6 +51,7 @@ public class UserController {
         log.info("api = 토큰 리프레시");
         User user = userService.getUserByRefreshToken(refreshToken);
         LoginDTO loginDTO = userService.issueNewTokens(user, response);
+        userService.setNewCookie(user, response);
 
         return CommonResponse.onSuccess(loginDTO);
     }

--- a/src/main/java/com/ceos/bankids/controller/request/ExpoRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/ExpoRequest.java
@@ -1,0 +1,23 @@
+package com.ceos.bankids.controller.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ExpoRequest {
+
+    @ApiModelProperty(example = "ExponentPushToken[asdfasdfasdf]")
+    @NotNull(message = "expoToken may not be null")
+    private String expoToken;
+}

--- a/src/main/java/com/ceos/bankids/dto/LoginDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/LoginDTO.java
@@ -19,14 +19,16 @@ public class LoginDTO {
     @ApiModelProperty(example = "kakao")
     private String provider;
 
-    public LoginDTO(Boolean isKid, String accessToken) {
+    public LoginDTO(Boolean isKid, String accessToken, String provider) {
         this.isKid = isKid;
         this.accessToken = accessToken;
+        this.provider = provider;
     }
 
-    public LoginDTO(Boolean isKid, String accessToken, Long level) {
+    public LoginDTO(Boolean isKid, String accessToken, Long level, String provider) {
         this.isKid = isKid;
         this.level = level;
         this.accessToken = accessToken;
+        this.provider = provider;
     }
 }

--- a/src/main/java/com/ceos/bankids/dto/LoginDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/LoginDTO.java
@@ -16,6 +16,8 @@ public class LoginDTO {
     private Long level;
     @ApiModelProperty(example = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ~~~~")
     private String accessToken;
+    @ApiModelProperty(example = "kakao")
+    private String provider;
 
     public LoginDTO(Boolean isKid, String accessToken) {
         this.isKid = isKid;

--- a/src/main/java/com/ceos/bankids/dto/oauth/AppleSubjectDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/oauth/AppleSubjectDTO.java
@@ -1,0 +1,20 @@
+package com.ceos.bankids.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppleSubjectDTO {
+
+    @JsonProperty("authenticationCode")
+    private String authenticationCode;
+
+}

--- a/src/main/java/com/ceos/bankids/service/AppleService.java
+++ b/src/main/java/com/ceos/bankids/service/AppleService.java
@@ -1,11 +1,9 @@
 package com.ceos.bankids.service;
 
 import com.ceos.bankids.controller.request.AppleRequest;
-import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.oauth.AppleKeyListDTO;
+import com.ceos.bankids.dto.oauth.AppleSubjectDTO;
 import com.ceos.bankids.dto.oauth.AppleTokenDTO;
-import io.jsonwebtoken.Claims;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.util.MultiValueMap;
 
@@ -14,15 +12,12 @@ public interface AppleService {
 
     public AppleKeyListDTO getAppleIdentityToken();
 
-    public Claims verifyIdentityToken(AppleRequest appleRequest,
+    public AppleSubjectDTO verifyIdentityToken(AppleRequest appleRequest,
         AppleKeyListDTO appleKeyListDTO);
 
     public AppleTokenDTO getAppleAccessToken(AppleRequest appleRequest);
 
     public Object revokeAppleAccount(AppleTokenDTO appleTokenDTO);
-
-    public LoginDTO loginWithAuthenticationCode(Claims claims, AppleRequest appleRequest,
-        HttpServletResponse response);
 
     public AppleRequest getAppleRequest(MultiValueMap<String, String> formData);
 }

--- a/src/main/java/com/ceos/bankids/service/KakaoService.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoService.java
@@ -1,10 +1,8 @@
 package com.ceos.bankids.service;
 
 import com.ceos.bankids.controller.request.KakaoRequest;
-import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.oauth.KakaoTokenDTO;
 import com.ceos.bankids.dto.oauth.KakaoUserDTO;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,7 +11,4 @@ public interface KakaoService {
     public KakaoTokenDTO getKakaoAccessToken(KakaoRequest kakaoRequest);
 
     public KakaoUserDTO getKakaoUserCode(KakaoTokenDTO kakaoTokenDTO);
-
-    public LoginDTO loginWithAuthenticationCode(KakaoUserDTO kakaoUserDTO,
-        HttpServletResponse response);
 }

--- a/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/KakaoServiceImpl.java
@@ -2,27 +2,19 @@ package com.ceos.bankids.service;
 
 import com.ceos.bankids.constant.ErrorCode;
 import com.ceos.bankids.controller.request.KakaoRequest;
-import com.ceos.bankids.domain.User;
-import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.oauth.KakaoTokenDTO;
 import com.ceos.bankids.dto.oauth.KakaoUserDTO;
 import com.ceos.bankids.exception.BadRequestException;
-import com.ceos.bankids.repository.UserRepository;
-import java.util.Optional;
-import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 @RequiredArgsConstructor
 public class KakaoServiceImpl implements KakaoService {
 
-    private final UserRepository uRepo;
     private final WebClient webClient;
-    private final UserServiceImpl userService;
 
     @Value("${kakao.key}")
     private String KAKAO_KEY;
@@ -63,26 +55,4 @@ public class KakaoServiceImpl implements KakaoService {
         }
     }
 
-    @Override
-    @Transactional
-    public LoginDTO loginWithAuthenticationCode(KakaoUserDTO kakaoUserDTO,
-        HttpServletResponse response) {
-        Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
-        if (user.isPresent()) {
-            LoginDTO loginDTO = userService.issueNewTokens(user.get(), response);
-
-            return loginDTO;
-        } else {
-            User newUser = User.builder()
-                .username(kakaoUserDTO.getKakaoAccount().getProfile().getNickname())
-                .authenticationCode(kakaoUserDTO.getAuthenticationCode())
-                .provider("kakao").refreshToken("")
-                .build();
-            uRepo.save(newUser);
-
-            LoginDTO loginDTO = userService.issueNewTokens(newUser, response);
-
-            return loginDTO;
-        }
-    }
 }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -21,7 +21,7 @@ public interface UserService {
 
     public UserDTO updateUserType(User user, UserTypeRequest userTypeRequest);
 
-    public LoginDTO issueNewTokens(User user);
+    public LoginDTO issueNewTokens(User user, String provider);
 
     public void setNewCookie(User user, HttpServletResponse response);
 

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -1,16 +1,24 @@
 package com.ceos.bankids.service;
 
+import com.ceos.bankids.controller.request.AppleRequest;
 import com.ceos.bankids.controller.request.ExpoRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.LoginDTO;
 import com.ceos.bankids.dto.MyPageDTO;
 import com.ceos.bankids.dto.UserDTO;
+import com.ceos.bankids.dto.oauth.KakaoUserDTO;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface UserService {
+
+    public LoginDTO loginWithKakaoAuthenticationCode(KakaoUserDTO kakaoUserDTO,
+        HttpServletResponse response);
+
+    public LoginDTO loginWithAppleAuthenticationCode(String authenticationCode,
+        AppleRequest appleRequest, HttpServletResponse response);
 
     public UserDTO updateUserType(User user, UserTypeRequest userTypeRequest);
 

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -1,5 +1,6 @@
 package com.ceos.bankids.service;
 
+import com.ceos.bankids.controller.request.ExpoRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.LoginDTO;
@@ -11,13 +12,17 @@ import org.springframework.stereotype.Service;
 @Service
 public interface UserService {
 
-    public UserDTO updateUserType(User authUser, UserTypeRequest userTypeRequest);
+    public UserDTO updateUserType(User user, UserTypeRequest userTypeRequest);
 
-    public LoginDTO issueNewTokens(User authUser, HttpServletResponse response);
+    public LoginDTO issueNewTokens(User user, HttpServletResponse response);
+
+    public void setNewCookie(User user, HttpServletResponse response);
 
     public MyPageDTO getUserInformation(User user);
 
     public User getUserByRefreshToken(String refreshToken);
 
-    public UserDTO updateUserLogout(User authUser);
+    public UserDTO updateUserLogout(User user);
+
+    public User updateUserExpoToken(User user, ExpoRequest expoRequest);
 }

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -14,15 +14,14 @@ import org.springframework.stereotype.Service;
 @Service
 public interface UserService {
 
-    public LoginDTO loginWithKakaoAuthenticationCode(KakaoUserDTO kakaoUserDTO,
-        HttpServletResponse response);
+    public LoginDTO loginWithKakaoAuthenticationCode(KakaoUserDTO kakaoUserDTO);
 
     public LoginDTO loginWithAppleAuthenticationCode(String authenticationCode,
-        AppleRequest appleRequest, HttpServletResponse response);
+        AppleRequest appleRequest);
 
     public UserDTO updateUserType(User user, UserTypeRequest userTypeRequest);
 
-    public LoginDTO issueNewTokens(User user, HttpServletResponse response);
+    public LoginDTO issueNewTokens(User user);
 
     public void setNewCookie(User user, HttpServletResponse response);
 

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -38,9 +38,10 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public LoginDTO loginWithKakaoAuthenticationCode(KakaoUserDTO kakaoUserDTO) {
+        String provider = "kakao";
         Optional<User> user = uRepo.findByAuthenticationCode(kakaoUserDTO.getAuthenticationCode());
         if (user.isPresent()) {
-            LoginDTO loginDTO = this.issueNewTokens(user.get());
+            LoginDTO loginDTO = this.issueNewTokens(user.get(), provider);
 
             return loginDTO;
         } else {
@@ -51,11 +52,11 @@ public class UserServiceImpl implements UserService {
             User newUser = User.builder()
                 .username(username)
                 .authenticationCode(kakaoUserDTO.getAuthenticationCode())
-                .provider("kakao").refreshToken("")
+                .provider(provider).refreshToken("")
                 .build();
             uRepo.save(newUser);
 
-            LoginDTO loginDTO = this.issueNewTokens(newUser);
+            LoginDTO loginDTO = this.issueNewTokens(newUser, provider);
 
             return loginDTO;
         }
@@ -66,9 +67,10 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public LoginDTO loginWithAppleAuthenticationCode(String authenticationCode,
         AppleRequest appleRequest) {
+        String provider = "apple";
         Optional<User> user = uRepo.findByAuthenticationCode(authenticationCode);
         if (user.isPresent()) {
-            LoginDTO loginDTO = this.issueNewTokens(user.get());
+            LoginDTO loginDTO = this.issueNewTokens(user.get(), provider);
 
             return loginDTO;
         } else {
@@ -83,7 +85,7 @@ public class UserServiceImpl implements UserService {
                 .build();
             uRepo.save(newUser);
 
-            LoginDTO loginDTO = this.issueNewTokens(newUser);
+            LoginDTO loginDTO = this.issueNewTokens(newUser, provider);
 
             return loginDTO;
         }
@@ -134,7 +136,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public LoginDTO issueNewTokens(User user) {
+    public LoginDTO issueNewTokens(User user, String provider) {
         String newRefreshToken = jwtTokenServiceImpl.encodeJwtRefreshToken(user.getId());
         user.setRefreshToken(newRefreshToken);
         uRepo.save(user);
@@ -144,11 +146,11 @@ public class UserServiceImpl implements UserService {
         LoginDTO loginDTO;
         if (user.getIsKid() == null || user.getIsKid() == false) {
             loginDTO = new LoginDTO(user.getIsKid(),
-                jwtTokenServiceImpl.encodeJwtToken(tokenDTO));
+                jwtTokenServiceImpl.encodeJwtToken(tokenDTO), provider);
         } else {
             loginDTO = new LoginDTO(user.getIsKid(),
                 jwtTokenServiceImpl.encodeJwtToken(tokenDTO),
-                user.getKid().getLevel());
+                user.getKid().getLevel(), provider);
         }
         return loginDTO;
     }

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.service;
 
 import com.ceos.bankids.constant.ErrorCode;
+import com.ceos.bankids.controller.request.ExpoRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.domain.Kid;
 import com.ceos.bankids.domain.Parent;
@@ -84,14 +85,6 @@ public class UserServiceImpl implements UserService {
 
         TokenDTO tokenDTO = new TokenDTO(user);
 
-        Cookie cookie = new Cookie("refreshToken", user.getRefreshToken());
-        cookie.setMaxAge(14 * 24 * 60 * 60);
-        cookie.setSecure(true);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-
-        response.addCookie(cookie);
-
         LoginDTO loginDTO;
         if (user.getIsKid() == null || user.getIsKid() == false) {
             loginDTO = new LoginDTO(user.getIsKid(),
@@ -102,6 +95,18 @@ public class UserServiceImpl implements UserService {
                 user.getKid().getLevel());
         }
         return loginDTO;
+    }
+
+    @Override
+    @Transactional
+    public void setNewCookie(User user, HttpServletResponse response) {
+        Cookie cookie = new Cookie("refreshToken", user.getRefreshToken());
+        cookie.setMaxAge(14 * 24 * 60 * 60);
+        cookie.setSecure(true);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
     }
 
     @Override
@@ -143,5 +148,14 @@ public class UserServiceImpl implements UserService {
         cookie.setPath("/");
 
         return null;
+    }
+
+    @Override
+    @Transactional
+    public User updateUserExpoToken(User user, ExpoRequest expoRequest) {
+        user.setExpoToken(expoRequest.getExpoToken());
+        uRepo.save(user);
+
+        return user;
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/AppleControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/AppleControllerTest.java
@@ -58,7 +58,7 @@ public class AppleControllerTest {
             .user(user)
             .build();
         user.setKid(kid);
-        LoginDTO login = new LoginDTO(true, "aT", 1L);
+        LoginDTO login = new LoginDTO(true, "aT", 1L, "apple");
 
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
@@ -121,7 +121,7 @@ public class AppleControllerTest {
             .isKid(null)
             .refreshToken("rT")
             .build();
-        LoginDTO login = new LoginDTO(null, "aT");
+        LoginDTO login = new LoginDTO(null, "aT", "apple");
 
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
@@ -189,7 +189,7 @@ public class AppleControllerTest {
             .isKid(null)
             .refreshToken("rT")
             .build();
-        LoginDTO login = new LoginDTO(null, "aT");
+        LoginDTO login = new LoginDTO(null, "aT", "apple");
 
         HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);

--- a/src/test/java/com/ceos/bankids/unit/controller/AppleControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/AppleControllerTest.java
@@ -1,0 +1,178 @@
+package com.ceos.bankids.unit.controller;
+
+import com.ceos.bankids.controller.AppleController;
+import com.ceos.bankids.controller.request.AppleRequest;
+import com.ceos.bankids.domain.Kid;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.TokenDTO;
+import com.ceos.bankids.dto.oauth.AppleKeyDTO;
+import com.ceos.bankids.dto.oauth.AppleKeyListDTO;
+import com.ceos.bankids.dto.oauth.AppleSubjectDTO;
+import com.ceos.bankids.dto.oauth.AppleTokenDTO;
+import com.ceos.bankids.repository.KidRepository;
+import com.ceos.bankids.repository.ParentRepository;
+import com.ceos.bankids.repository.UserRepository;
+import com.ceos.bankids.service.AppleServiceImpl;
+import com.ceos.bankids.service.JwtTokenServiceImpl;
+import com.ceos.bankids.service.UserServiceImpl;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.util.MultiValueMap;
+
+public class AppleControllerTest {
+
+    private AppleKeyDTO appleKeyDTO1 = new AppleKeyDTO("RSA", "fh6Bs8C", "sig", "RS256",
+        "u704gotMSZc6CSSVNCZ1d0S9dZKwO2BVzfdTKYz8wSNm7R_KIufOQf3ru7Pph1FjW6gQ8zgvhnv4IebkGWsZJlodduTC7c0sRb5PZpEyM6PtO8FPHowaracJJsK1f6_rSLstLdWbSDXeSq7vBvDu3Q31RaoV_0YlEzQwPsbCvD45oVy5Vo5oBePUm4cqi6T3cZ-10gr9QJCVwvx7KiQsttp0kUkHM94PlxbG_HAWlEZjvAlxfEDc-_xZQwC6fVjfazs3j1b2DZWsGmBRdx1snO75nM7hpyRRQB4jVejW9TuZDtPtsNadXTr9I5NjxPdIYMORj9XKEh44Z73yfv0gtw",
+        "AQAB");
+    private AppleKeyDTO appleKeyDTO2 = new AppleKeyDTO("RSA", "W6WcOKB", "sig", "RS256",
+        "2Zc5d0-zkZ5AKmtYTvxHc3vRc41YfbklflxG9SWsg5qXUxvfgpktGAcxXLFAd9Uglzow9ezvmTGce5d3DhAYKwHAEPT9hbaMDj7DfmEwuNO8UahfnBkBXsCoUaL3QITF5_DAPsZroTqs7tkQQZ7qPkQXCSu2aosgOJmaoKQgwcOdjD0D49ne2B_dkxBcNCcJT9pTSWJ8NfGycjWAQsvC8CGstH8oKwhC5raDcc2IGXMOQC7Qr75d6J5Q24CePHj_JD7zjbwYy9KNH8wyr829eO_G4OEUW50FAN6HKtvjhJIguMl_1BLZ93z2KJyxExiNTZBUBQbbgCNBfzTv7JrxMw",
+        "AQAB");
+    private AppleKeyDTO appleKeyDTO3 = new AppleKeyDTO("RSA", "YuyXoY", "sig", "RS256",
+        "1JiU4l3YCeT4o0gVmxGTEK1IXR-Ghdg5Bzka12tzmtdCxU00ChH66aV-4HRBjF1t95IsaeHeDFRgmF0lJbTDTqa6_VZo2hc0zTiUAsGLacN6slePvDcR1IMucQGtPP5tGhIbU-HKabsKOFdD4VQ5PCXifjpN9R-1qOR571BxCAl4u1kUUIePAAJcBcqGRFSI_I1j_jbN3gflK_8ZNmgnPrXA0kZXzj1I7ZHgekGbZoxmDrzYm2zmja1MsE5A_JX7itBYnlR41LOtvLRCNtw7K3EFlbfB6hkPL-Swk5XNGbWZdTROmaTNzJhV-lWT0gGm6V1qWAK2qOZoIDa_3Ud0Gw",
+        "AQAB");
+
+    @Test
+    @DisplayName("기존 자녀 유저가 애플 로그인 성공 시, 결과 반환하는지 확인")
+    public void testIfKidAppleLoginSucceedReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("ozzing")
+            .isFemale(true)
+            .authenticationCode("1234")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("rT")
+            .build();
+        Kid kid = Kid.builder()
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+        LoginDTO login = new LoginDTO(true, "aT", 1L);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findByAuthenticationCode("1234")).thenReturn(
+            Optional.ofNullable(user));
+        KidRepository kidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        Mockito.doReturn("rT").when(jwtTokenServiceImpl).encodeJwtRefreshToken(1L);
+        Mockito.doReturn("aT").when(jwtTokenServiceImpl).encodeJwtToken(new TokenDTO(user));
+        MultiValueMap<String, String> formData = null;
+
+        AppleRequest appleRequest = new AppleRequest("code",
+            "eyJraWQiOiJmaDZCczhDIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLmJhbmtpZHouYmFua2lkei13ZWIiLCJleHAiOjE2NjE5MzUyNDEsImlhdCI6MTY2MTg0ODg0MSwic3ViIjoiMDAxMzYyLjE0ZjNiODk3ZDY2MTRlZjI4ODZiZDM5NDIyZGE5ZGY0LjA5MzUiLCJub25jZSI6ImhpIiwiY19oYXNoIjoiWnplMVpsOGhXLUFwdDRHbHpBUk9ZUSIsImF1dGhfdGltZSI6MTY2MTg0ODg0MSwibm9uY2Vfc3VwcG9ydGVkIjp0cnVlfQ.lwp2PLBkaGm08riMEMWrzZREXfbMMQvxnYppUENgeWCOq76BdrTdLHpEMnYNiTzGSEXgXtFw8TQZIPY4uPJfEmHZ0lxoiHaReloaGHISZBt50wC2eEYI3-0CPM5sB-GMa8rExYxfq8FL6BbRf5g9jIDhdOfJa4X9xqtJFgfbGf8NMTHnVV8YvjmNkWpFotVcjHHUkkjqo_8u8YA-DFDQr46hDvDzIL2Oq2q10EhD9Z3BubfJQV5QgIfot1BMOMmAvyXANzAN1YEJUhkDNlbaY3fiBtyCYWRzbNi8cX5jW69lkIT4Isxxw5Tj3GvlQRjkC_OA3TuzO8jq87bjQjTPcw",
+            "ozzing");
+        List<AppleKeyDTO> appleKeyDTOList = new ArrayList<>();
+        appleKeyDTOList.add(appleKeyDTO1);
+        appleKeyDTOList.add(appleKeyDTO2);
+        appleKeyDTOList.add(appleKeyDTO3);
+        AppleKeyListDTO appleKeyListDTO = new AppleKeyListDTO(appleKeyDTOList);
+        AppleSubjectDTO appleSubjectDTO = new AppleSubjectDTO("1234");
+        AppleTokenDTO appleTokenDTO = null;
+
+        AppleServiceImpl appleService = Mockito.mock(AppleServiceImpl.class);
+        Mockito.doReturn(appleRequest).when(appleService).getAppleRequest(formData);
+        Mockito.doReturn(appleKeyListDTO).when(appleService).getAppleIdentityToken();
+        Mockito.doReturn(appleSubjectDTO).when(appleService)
+            .verifyIdentityToken(appleRequest, appleKeyListDTO);
+        Mockito.doReturn(appleTokenDTO).when(appleService).getAppleAccessToken(appleRequest);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            kidRepository,
+            parentRepository,
+            jwtTokenServiceImpl
+        );
+        AppleController appleController = new AppleController(
+            appleService,
+            userService
+        );
+
+        // then
+        try {
+            appleController.postAppleLogin(formData, response);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    @DisplayName("새로운 유저가 애플 로그인 성공 시, 결과 반환하는지 확인")
+    public void testIfNewUserAppleLoginSucceedReturnResult() {
+        // given
+        User user = User.builder()
+            .username("ozzing")
+            .isFemale(null)
+            .authenticationCode("1234")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("rT")
+            .build();
+        LoginDTO login = new LoginDTO(null, "aT");
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findByAuthenticationCode("1234")).thenReturn(
+            Optional.ofNullable(null));
+        KidRepository kidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        Mockito.doReturn("rT").when(jwtTokenServiceImpl).encodeJwtRefreshToken(1L);
+        Mockito.doReturn("aT").when(jwtTokenServiceImpl).encodeJwtToken(new TokenDTO(user));
+        MultiValueMap<String, String> formData = null;
+
+        AppleRequest appleRequest = new AppleRequest("code",
+            "eyJraWQiOiJmaDZCczhDIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLmJhbmtpZHouYmFua2lkei13ZWIiLCJleHAiOjE2NjE5MzUyNDEsImlhdCI6MTY2MTg0ODg0MSwic3ViIjoiMDAxMzYyLjE0ZjNiODk3ZDY2MTRlZjI4ODZiZDM5NDIyZGE5ZGY0LjA5MzUiLCJub25jZSI6ImhpIiwiY19oYXNoIjoiWnplMVpsOGhXLUFwdDRHbHpBUk9ZUSIsImF1dGhfdGltZSI6MTY2MTg0ODg0MSwibm9uY2Vfc3VwcG9ydGVkIjp0cnVlfQ.lwp2PLBkaGm08riMEMWrzZREXfbMMQvxnYppUENgeWCOq76BdrTdLHpEMnYNiTzGSEXgXtFw8TQZIPY4uPJfEmHZ0lxoiHaReloaGHISZBt50wC2eEYI3-0CPM5sB-GMa8rExYxfq8FL6BbRf5g9jIDhdOfJa4X9xqtJFgfbGf8NMTHnVV8YvjmNkWpFotVcjHHUkkjqo_8u8YA-DFDQr46hDvDzIL2Oq2q10EhD9Z3BubfJQV5QgIfot1BMOMmAvyXANzAN1YEJUhkDNlbaY3fiBtyCYWRzbNi8cX5jW69lkIT4Isxxw5Tj3GvlQRjkC_OA3TuzO8jq87bjQjTPcw",
+            "ozzing");
+        List<AppleKeyDTO> appleKeyDTOList = new ArrayList<>();
+        appleKeyDTOList.add(appleKeyDTO1);
+        appleKeyDTOList.add(appleKeyDTO2);
+        appleKeyDTOList.add(appleKeyDTO3);
+        AppleKeyListDTO appleKeyListDTO = new AppleKeyListDTO(appleKeyDTOList);
+        AppleSubjectDTO appleSubjectDTO = new AppleSubjectDTO("1234");
+        AppleTokenDTO appleTokenDTO = null;
+
+        AppleServiceImpl appleService = Mockito.mock(AppleServiceImpl.class);
+        Mockito.doReturn(appleRequest).when(appleService).getAppleRequest(formData);
+        Mockito.doReturn(appleKeyListDTO).when(appleService).getAppleIdentityToken();
+        Mockito.doReturn(appleSubjectDTO).when(appleService)
+            .verifyIdentityToken(appleRequest, appleKeyListDTO);
+        Mockito.doReturn(appleTokenDTO).when(appleService).getAppleAccessToken(appleRequest);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            kidRepository,
+            parentRepository,
+            jwtTokenServiceImpl
+        );
+        AppleController appleController = new AppleController(
+            appleService,
+            userService
+        );
+
+        // then
+        try {
+            appleController.postAppleLogin(formData, response);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(2)).save(uCaptor.capture());
+        Assertions.assertEquals(user, uCaptor.getValue());
+    }
+}

--- a/src/test/java/com/ceos/bankids/unit/controller/AppleControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/AppleControllerTest.java
@@ -245,4 +245,65 @@ public class AppleControllerTest {
         Assertions.assertEquals(user, uCaptor.getValue());
         Assertions.assertEquals(user.getUsername(), uCaptor.getValue().getUsername());
     }
+
+    @Test
+    @DisplayName("유저 탈퇴 전 애플 연동 해제 성공 시, 리다이렉트하는지 확인")
+    public void testIfUserRevokeSucceedReturnResult() {
+        // given
+        User user = User.builder()
+            .username("홍길동")
+            .isFemale(null)
+            .authenticationCode("1234")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("rT")
+            .build();
+        LoginDTO login = new LoginDTO(null, "aT", "apple");
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository kidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        MultiValueMap<String, String> formData = null;
+
+        AppleRequest appleRequest = new AppleRequest("code",
+            "eyJraWQiOiJmaDZCczhDIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLmJhbmtpZHouYmFua2lkei13ZWIiLCJleHAiOjE2NjE5MzUyNDEsImlhdCI6MTY2MTg0ODg0MSwic3ViIjoiMDAxMzYyLjE0ZjNiODk3ZDY2MTRlZjI4ODZiZDM5NDIyZGE5ZGY0LjA5MzUiLCJub25jZSI6ImhpIiwiY19oYXNoIjoiWnplMVpsOGhXLUFwdDRHbHpBUk9ZUSIsImF1dGhfdGltZSI6MTY2MTg0ODg0MSwibm9uY2Vfc3VwcG9ydGVkIjp0cnVlfQ.lwp2PLBkaGm08riMEMWrzZREXfbMMQvxnYppUENgeWCOq76BdrTdLHpEMnYNiTzGSEXgXtFw8TQZIPY4uPJfEmHZ0lxoiHaReloaGHISZBt50wC2eEYI3-0CPM5sB-GMa8rExYxfq8FL6BbRf5g9jIDhdOfJa4X9xqtJFgfbGf8NMTHnVV8YvjmNkWpFotVcjHHUkkjqo_8u8YA-DFDQr46hDvDzIL2Oq2q10EhD9Z3BubfJQV5QgIfot1BMOMmAvyXANzAN1YEJUhkDNlbaY3fiBtyCYWRzbNi8cX5jW69lkIT4Isxxw5Tj3GvlQRjkC_OA3TuzO8jq87bjQjTPcw",
+            user.getUsername());
+        List<AppleKeyDTO> appleKeyDTOList = new ArrayList<>();
+        appleKeyDTOList.add(appleKeyDTO1);
+        appleKeyDTOList.add(appleKeyDTO2);
+        appleKeyDTOList.add(appleKeyDTO3);
+        AppleKeyListDTO appleKeyListDTO = new AppleKeyListDTO(appleKeyDTOList);
+        AppleSubjectDTO appleSubjectDTO = new AppleSubjectDTO("1234");
+        AppleTokenDTO appleTokenDTO = null;
+        Object object = null;
+
+        AppleServiceImpl appleService = Mockito.mock(AppleServiceImpl.class);
+        Mockito.doReturn(appleRequest).when(appleService).getAppleRequest(formData);
+        Mockito.doReturn(appleKeyListDTO).when(appleService).getAppleIdentityToken();
+        Mockito.doReturn(appleSubjectDTO).when(appleService)
+            .verifyIdentityToken(appleRequest, appleKeyListDTO);
+        Mockito.doReturn(appleTokenDTO).when(appleService).getAppleAccessToken(appleRequest);
+        Mockito.doReturn(object).when(appleService).revokeAppleAccount(appleTokenDTO);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            kidRepository,
+            parentRepository,
+            jwtTokenServiceImpl
+        );
+        AppleController appleController = new AppleController(
+            appleService,
+            userService
+        );
+
+        // then
+        try {
+            appleController.deleteAppleLogin(formData, response);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/AppleControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/AppleControllerTest.java
@@ -114,7 +114,7 @@ public class AppleControllerTest {
     public void testIfNewUserAppleLoginSucceedReturnResult() {
         // given
         User user = User.builder()
-            .username("ozzing")
+            .username("홍길동")
             .isFemale(null)
             .authenticationCode("1234")
             .provider("kakao")
@@ -136,7 +136,7 @@ public class AppleControllerTest {
 
         AppleRequest appleRequest = new AppleRequest("code",
             "eyJraWQiOiJmaDZCczhDIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLmJhbmtpZHouYmFua2lkei13ZWIiLCJleHAiOjE2NjE5MzUyNDEsImlhdCI6MTY2MTg0ODg0MSwic3ViIjoiMDAxMzYyLjE0ZjNiODk3ZDY2MTRlZjI4ODZiZDM5NDIyZGE5ZGY0LjA5MzUiLCJub25jZSI6ImhpIiwiY19oYXNoIjoiWnplMVpsOGhXLUFwdDRHbHpBUk9ZUSIsImF1dGhfdGltZSI6MTY2MTg0ODg0MSwibm9uY2Vfc3VwcG9ydGVkIjp0cnVlfQ.lwp2PLBkaGm08riMEMWrzZREXfbMMQvxnYppUENgeWCOq76BdrTdLHpEMnYNiTzGSEXgXtFw8TQZIPY4uPJfEmHZ0lxoiHaReloaGHISZBt50wC2eEYI3-0CPM5sB-GMa8rExYxfq8FL6BbRf5g9jIDhdOfJa4X9xqtJFgfbGf8NMTHnVV8YvjmNkWpFotVcjHHUkkjqo_8u8YA-DFDQr46hDvDzIL2Oq2q10EhD9Z3BubfJQV5QgIfot1BMOMmAvyXANzAN1YEJUhkDNlbaY3fiBtyCYWRzbNi8cX5jW69lkIT4Isxxw5Tj3GvlQRjkC_OA3TuzO8jq87bjQjTPcw",
-            "ozzing");
+            user.getUsername());
         List<AppleKeyDTO> appleKeyDTOList = new ArrayList<>();
         appleKeyDTOList.add(appleKeyDTO1);
         appleKeyDTOList.add(appleKeyDTO2);
@@ -174,5 +174,75 @@ public class AppleControllerTest {
         ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
         Mockito.verify(mockUserRepository, Mockito.times(2)).save(uCaptor.capture());
         Assertions.assertEquals(user, uCaptor.getValue());
+        Assertions.assertEquals(user.getUsername(), uCaptor.getValue().getUsername());
+    }
+
+    @Test
+    @DisplayName("이름이 긴 새로운 유저가 애플 로그인 성공 시, 결과 반환하는지 확인")
+    public void testIfNewUserWithLongNameAppleLoginSucceedReturnResult() {
+        // given
+        User user = User.builder()
+            .username("홍길동그라미")
+            .isFemale(null)
+            .authenticationCode("1234")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("rT")
+            .build();
+        LoginDTO login = new LoginDTO(null, "aT");
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findByAuthenticationCode("1234")).thenReturn(
+            Optional.ofNullable(null));
+        KidRepository kidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
+        MultiValueMap<String, String> formData = null;
+
+        AppleRequest appleRequest = new AppleRequest("code",
+            "eyJraWQiOiJmaDZCczhDIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLmJhbmtpZHouYmFua2lkei13ZWIiLCJleHAiOjE2NjE5MzUyNDEsImlhdCI6MTY2MTg0ODg0MSwic3ViIjoiMDAxMzYyLjE0ZjNiODk3ZDY2MTRlZjI4ODZiZDM5NDIyZGE5ZGY0LjA5MzUiLCJub25jZSI6ImhpIiwiY19oYXNoIjoiWnplMVpsOGhXLUFwdDRHbHpBUk9ZUSIsImF1dGhfdGltZSI6MTY2MTg0ODg0MSwibm9uY2Vfc3VwcG9ydGVkIjp0cnVlfQ.lwp2PLBkaGm08riMEMWrzZREXfbMMQvxnYppUENgeWCOq76BdrTdLHpEMnYNiTzGSEXgXtFw8TQZIPY4uPJfEmHZ0lxoiHaReloaGHISZBt50wC2eEYI3-0CPM5sB-GMa8rExYxfq8FL6BbRf5g9jIDhdOfJa4X9xqtJFgfbGf8NMTHnVV8YvjmNkWpFotVcjHHUkkjqo_8u8YA-DFDQr46hDvDzIL2Oq2q10EhD9Z3BubfJQV5QgIfot1BMOMmAvyXANzAN1YEJUhkDNlbaY3fiBtyCYWRzbNi8cX5jW69lkIT4Isxxw5Tj3GvlQRjkC_OA3TuzO8jq87bjQjTPcw",
+            user.getUsername());
+        List<AppleKeyDTO> appleKeyDTOList = new ArrayList<>();
+        appleKeyDTOList.add(appleKeyDTO1);
+        appleKeyDTOList.add(appleKeyDTO2);
+        appleKeyDTOList.add(appleKeyDTO3);
+        AppleKeyListDTO appleKeyListDTO = new AppleKeyListDTO(appleKeyDTOList);
+        AppleSubjectDTO appleSubjectDTO = new AppleSubjectDTO("1234");
+        AppleTokenDTO appleTokenDTO = null;
+
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        Mockito.doReturn("rT").when(jwtTokenServiceImpl).encodeJwtRefreshToken(1L);
+        user.setUsername(user.getUsername().substring(0, 3));
+        Mockito.doReturn("aT").when(jwtTokenServiceImpl).encodeJwtToken(new TokenDTO(user));
+        AppleServiceImpl appleService = Mockito.mock(AppleServiceImpl.class);
+        Mockito.doReturn(appleRequest).when(appleService).getAppleRequest(formData);
+        Mockito.doReturn(appleKeyListDTO).when(appleService).getAppleIdentityToken();
+        Mockito.doReturn(appleSubjectDTO).when(appleService)
+            .verifyIdentityToken(appleRequest, appleKeyListDTO);
+        Mockito.doReturn(appleTokenDTO).when(appleService).getAppleAccessToken(appleRequest);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            kidRepository,
+            parentRepository,
+            jwtTokenServiceImpl
+        );
+        AppleController appleController = new AppleController(
+            appleService,
+            userService
+        );
+
+        // then
+        try {
+            appleController.postAppleLogin(formData, response);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(2)).save(uCaptor.capture());
+        Assertions.assertEquals(user, uCaptor.getValue());
+        Assertions.assertEquals(user.getUsername(), uCaptor.getValue().getUsername());
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/KakaoControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/KakaoControllerTest.java
@@ -118,7 +118,7 @@ public class KakaoControllerTest {
             .user(user)
             .build();
         user.setKid(kid);
-        LoginDTO login = new LoginDTO(true, "aT", 1L);
+        LoginDTO login = new LoginDTO(true, "aT", 1L, "kakao");
 
         HttpServletResponse response = null;
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
@@ -177,7 +177,7 @@ public class KakaoControllerTest {
         CommonResponse<LoginDTO> result = kakaoController.postKakaoLogin(kakaoRequest, response);
 
         // then
-        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L);
+        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L, "kakao");
         Assertions.assertEquals(loginDTO, result.getData());
     }
 
@@ -194,7 +194,7 @@ public class KakaoControllerTest {
             .isKid(false)
             .refreshToken("rT")
             .build();
-        LoginDTO login = new LoginDTO(false, "aT");
+        LoginDTO login = new LoginDTO(false, "aT", "kakao");
 
         HttpServletResponse response = null;
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
@@ -205,7 +205,7 @@ public class KakaoControllerTest {
             RequestBodyUriSpec.class);
         WebClient.ResponseSpec responseSpec = Mockito.mock(ResponseSpec.class);
         UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
-        Mockito.when(mockUserService.issueNewTokens(user)).thenReturn(login);
+        Mockito.when(mockUserService.issueNewTokens(user, "kakao")).thenReturn(login);
         KidRepository kidRepository = Mockito.mock(KidRepository.class);
         ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
@@ -255,7 +255,7 @@ public class KakaoControllerTest {
         CommonResponse<LoginDTO> result = kakaoController.postKakaoLogin(kakaoRequest, response);
 
         // then
-        LoginDTO loginDTO = new LoginDTO(false, "aT");
+        LoginDTO loginDTO = new LoginDTO(false, "aT", "kakao");
         Assertions.assertEquals(loginDTO, result.getData());
     }
 
@@ -339,7 +339,7 @@ public class KakaoControllerTest {
         Assertions.assertEquals(user.getUsername(), uCaptor.getValue().getUsername());
 
         // then
-        LoginDTO loginDTO = new LoginDTO(null, "aT");
+        LoginDTO loginDTO = new LoginDTO(null, "aT", "kakao");
         Assertions.assertEquals(loginDTO, result.getData());
     }
 
@@ -381,7 +381,7 @@ public class KakaoControllerTest {
         Mockito.doReturn("rT").when(mockJwtTokenServiceImpl).encodeJwtRefreshToken(1L);
         user.setUsername(user.getUsername().substring(0, 3));
         Mockito.doReturn("aT").when(mockJwtTokenServiceImpl).encodeJwtToken(new TokenDTO(user));
-        
+
         String getTokenURL =
             "https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id="
                 + "null" + "&redirect_uri=" + "null" + "&code="
@@ -424,7 +424,7 @@ public class KakaoControllerTest {
         Assertions.assertEquals(user.getUsername(), uCaptor.getValue().getUsername());
 
         // then
-        LoginDTO loginDTO = new LoginDTO(null, "aT");
+        LoginDTO loginDTO = new LoginDTO(null, "aT", "kakao");
         Assertions.assertEquals(loginDTO, result.getData());
     }
 
@@ -440,7 +440,7 @@ public class KakaoControllerTest {
             .isKid(null)
             .refreshToken("rT")
             .build();
-        LoginDTO login = new LoginDTO(null, "aT");
+        LoginDTO login = new LoginDTO(null, "aT", "kakao");
 
         HttpServletResponse response = null;
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
@@ -451,7 +451,7 @@ public class KakaoControllerTest {
             RequestBodyUriSpec.class);
         WebClient.ResponseSpec responseSpec = Mockito.mock(ResponseSpec.class);
         UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
-        Mockito.when(mockUserService.issueNewTokens(user)).thenReturn(login);
+        Mockito.when(mockUserService.issueNewTokens(user, "kakao")).thenReturn(login);
         KidRepository kidRepository = Mockito.mock(KidRepository.class);
         ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
@@ -515,7 +515,7 @@ public class KakaoControllerTest {
             .isKid(null)
             .refreshToken("rT")
             .build();
-        LoginDTO login = new LoginDTO(null, "aT");
+        LoginDTO login = new LoginDTO(null, "aT", "kakao");
 
         HttpServletResponse response = null;
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
@@ -526,7 +526,7 @@ public class KakaoControllerTest {
             RequestBodyUriSpec.class);
         WebClient.ResponseSpec responseSpec = Mockito.mock(ResponseSpec.class);
         UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
-        Mockito.when(mockUserService.issueNewTokens(user)).thenReturn(login);
+        Mockito.when(mockUserService.issueNewTokens(user, "kakao")).thenReturn(login);
         KidRepository kidRepository = Mockito.mock(KidRepository.class);
         ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);

--- a/src/test/java/com/ceos/bankids/unit/controller/KakaoControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/KakaoControllerTest.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClient.RequestBodyUriSpec;
@@ -204,7 +205,7 @@ public class KakaoControllerTest {
             RequestBodyUriSpec.class);
         WebClient.ResponseSpec responseSpec = Mockito.mock(ResponseSpec.class);
         UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
-        Mockito.when(mockUserService.issueNewTokens(user, response)).thenReturn(login);
+        Mockito.when(mockUserService.issueNewTokens(user)).thenReturn(login);
         KidRepository kidRepository = Mockito.mock(KidRepository.class);
         ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
@@ -263,34 +264,36 @@ public class KakaoControllerTest {
     public void testIfNewUserKakaoLoginSucceedReturnResult() {
         // given
         User user = User.builder()
-            .username("ozzing")
+            .username("홍길동")
             .isFemale(null)
             .authenticationCode("1234")
             .provider("kakao")
             .isKid(null)
             .refreshToken("rT")
             .build();
-        LoginDTO login = new LoginDTO(null, "aT");
+        LoginDTO login = new LoginDTO(null, "aT", null);
 
         HttpServletResponse response = null;
+
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         Mockito.when(mockUserRepository.findByAuthenticationCode("1234")).thenReturn(
             Optional.ofNullable(null));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+
         WebClient mockWebClient = Mockito.mock(WebClient.class);
         WebClient.RequestBodyUriSpec requestBodyUriSpec = Mockito.mock(
             RequestBodyUriSpec.class);
         WebClient.ResponseSpec responseSpec = Mockito.mock(ResponseSpec.class);
-        UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
-        Mockito.when(mockUserService.issueNewTokens(user, response)).thenReturn(login);
-        KidRepository kidRepository = Mockito.mock(KidRepository.class);
-        ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
-        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-        Mockito.doReturn("rT").when(jwtTokenServiceImpl).encodeJwtRefreshToken(1L);
-        Mockito.doReturn("aT").when(jwtTokenServiceImpl).encodeJwtToken(new TokenDTO(user));
+
+        JwtTokenServiceImpl mockJwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        Mockito.doReturn("rT").when(mockJwtTokenServiceImpl).encodeJwtRefreshToken(1L);
+        Mockito.doReturn("aT").when(mockJwtTokenServiceImpl).encodeJwtToken(new TokenDTO(user));
 
         KakaoRequest kakaoRequest = new KakaoRequest("aT");
         KakaoTokenDTO kakaoTokenDTO = new KakaoTokenDTO("aT", "rT");
-        KakaoAccountDTO kakaoAccountDTO = new KakaoAccountDTO(new KakaoProfileDTO("ozzing"));
+        KakaoAccountDTO kakaoAccountDTO = new KakaoAccountDTO(
+            new KakaoProfileDTO(user.getUsername()));
         Timestamp timeStamp = Timestamp.valueOf(LocalDateTime.now());
         KakaoUserDTO kakaoUserDTO = new KakaoUserDTO("1234", timeStamp, kakaoAccountDTO);
 
@@ -320,15 +323,105 @@ public class KakaoControllerTest {
         );
         UserServiceImpl userService = new UserServiceImpl(
             mockUserRepository,
-            kidRepository,
-            parentRepository,
-            jwtTokenServiceImpl
+            mockKidRepository,
+            mockParentRepository,
+            mockJwtTokenServiceImpl
         );
         KakaoController kakaoController = new KakaoController(
             kakaoService,
             userService
         );
+
         CommonResponse<LoginDTO> result = kakaoController.postKakaoLogin(kakaoRequest, response);
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(2)).save(uCaptor.capture());
+        Assertions.assertEquals(user, uCaptor.getValue());
+        Assertions.assertEquals(user.getUsername(), uCaptor.getValue().getUsername());
+
+        // then
+        LoginDTO loginDTO = new LoginDTO(null, "aT");
+        Assertions.assertEquals(loginDTO, result.getData());
+    }
+
+    @Test
+    @DisplayName("이름이 긴 새로운 유저가 카카오 로그인 성공 시, 결과 반환하는지 확인")
+    public void testIfNewUserWithLongNameKakaoLoginSucceedReturnResult() {
+        // given
+        User user = User.builder()
+            .username("홍길동그라미")
+            .isFemale(null)
+            .authenticationCode("1234")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("rT")
+            .build();
+        LoginDTO login = new LoginDTO(null, "aT", null);
+
+        HttpServletResponse response = null;
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findByAuthenticationCode("1234")).thenReturn(
+            Optional.ofNullable(null));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+
+        WebClient mockWebClient = Mockito.mock(WebClient.class);
+        WebClient.RequestBodyUriSpec requestBodyUriSpec = Mockito.mock(
+            RequestBodyUriSpec.class);
+        WebClient.ResponseSpec responseSpec = Mockito.mock(ResponseSpec.class);
+
+        KakaoRequest kakaoRequest = new KakaoRequest("aT");
+        KakaoTokenDTO kakaoTokenDTO = new KakaoTokenDTO("aT", "rT");
+        KakaoAccountDTO kakaoAccountDTO = new KakaoAccountDTO(
+            new KakaoProfileDTO(user.getUsername()));
+        Timestamp timeStamp = Timestamp.valueOf(LocalDateTime.now());
+        KakaoUserDTO kakaoUserDTO = new KakaoUserDTO("1234", timeStamp, kakaoAccountDTO);
+
+        JwtTokenServiceImpl mockJwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        Mockito.doReturn("rT").when(mockJwtTokenServiceImpl).encodeJwtRefreshToken(1L);
+        user.setUsername(user.getUsername().substring(0, 3));
+        Mockito.doReturn("aT").when(mockJwtTokenServiceImpl).encodeJwtToken(new TokenDTO(user));
+        
+        String getTokenURL =
+            "https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id="
+                + "null" + "&redirect_uri=" + "null" + "&code="
+                + kakaoRequest.getCode();
+        String getUserURL = "https://kapi.kakao.com/v2/user/me";
+
+        Mockito.when(mockWebClient.post()).thenReturn(requestBodyUriSpec);
+        Mockito.when(requestBodyUriSpec.uri(getTokenURL)).thenReturn(requestBodyUriSpec);
+        Mockito.when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        Mockito.when(responseSpec.bodyToMono(KakaoTokenDTO.class))
+            .thenReturn(Mono.just(kakaoTokenDTO));
+
+        Mockito.when(mockWebClient.post()).thenReturn(requestBodyUriSpec);
+        Mockito.when(requestBodyUriSpec.uri(getUserURL)).thenReturn(requestBodyUriSpec);
+        Mockito.when(requestBodyUriSpec.header("Authorization", "Bearer " + "aT"))
+            .thenReturn(requestBodyUriSpec);
+        Mockito.when(requestBodyUriSpec.retrieve()).thenReturn(responseSpec);
+        Mockito.when(responseSpec.bodyToMono(KakaoUserDTO.class))
+            .thenReturn(Mono.just(kakaoUserDTO));
+
+        // when
+        KakaoServiceImpl kakaoService = new KakaoServiceImpl(
+            mockWebClient
+        );
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            mockJwtTokenServiceImpl
+        );
+        KakaoController kakaoController = new KakaoController(
+            kakaoService,
+            userService
+        );
+
+        CommonResponse<LoginDTO> result = kakaoController.postKakaoLogin(kakaoRequest, response);
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(2)).save(uCaptor.capture());
+        Assertions.assertEquals(user, uCaptor.getValue());
+        Assertions.assertEquals(user.getUsername(), uCaptor.getValue().getUsername());
 
         // then
         LoginDTO loginDTO = new LoginDTO(null, "aT");
@@ -358,7 +451,7 @@ public class KakaoControllerTest {
             RequestBodyUriSpec.class);
         WebClient.ResponseSpec responseSpec = Mockito.mock(ResponseSpec.class);
         UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
-        Mockito.when(mockUserService.issueNewTokens(user, response)).thenReturn(login);
+        Mockito.when(mockUserService.issueNewTokens(user)).thenReturn(login);
         KidRepository kidRepository = Mockito.mock(KidRepository.class);
         ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
@@ -433,7 +526,7 @@ public class KakaoControllerTest {
             RequestBodyUriSpec.class);
         WebClient.ResponseSpec responseSpec = Mockito.mock(ResponseSpec.class);
         UserServiceImpl mockUserService = Mockito.mock(UserServiceImpl.class);
-        Mockito.when(mockUserService.issueNewTokens(user, response)).thenReturn(login);
+        Mockito.when(mockUserService.issueNewTokens(user)).thenReturn(login);
         KidRepository kidRepository = Mockito.mock(KidRepository.class);
         ParentRepository parentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.ceos.bankids.unit.controller;
 
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.UserController;
+import com.ceos.bankids.controller.request.ExpoRequest;
 import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.controller.request.WithdrawalRequest;
@@ -1407,5 +1408,64 @@ public class UserControllerTest {
 
         // then
         Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+    @Test
+    @DisplayName("유저 엑스포 토큰 패치 성공 시, null 반환하는지 확인")
+    public void testIfUserExpoTokenPatchSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .expoToken("ExponentPushToken[dd]")
+            .build();
+        ExpoRequest expoRequest = new ExpoRequest("ExponentPushToken[dd]");
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(
+            mockUserRepository,
+            mockKidRepository,
+            mockParentRepository,
+            jwtTokenServiceImpl
+        );
+        FamilyServiceImpl familyService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+
+        UserController userController = new UserController(
+            userService,
+            familyService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService
+        );
+
+        CommonResponse result = userController.patchExpoToken(user, expoRequest, response);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -604,7 +604,7 @@ public class UserControllerTest {
         CommonResponse result = userController.refreshUserToken("rT", response);
 
         // then
-        LoginDTO loginDTO = new LoginDTO(false, "aT");
+        LoginDTO loginDTO = new LoginDTO(false, "aT", user.getProvider());
         Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
     }
 
@@ -669,7 +669,7 @@ public class UserControllerTest {
         CommonResponse result = userController.refreshUserToken("rT", response);
 
         // then
-        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L);
+        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L, user.getProvider());
         Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
     }
 
@@ -730,7 +730,7 @@ public class UserControllerTest {
         CommonResponse result = userController.refreshUserToken("rT", response);
 
         // then
-        LoginDTO loginDTO = new LoginDTO(null, "aT");
+        LoginDTO loginDTO = new LoginDTO(null, "aT", user.getProvider());
         Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
     }
 


### PR DESCRIPTION
## 📝 PR Summary

*로그인*
- 애플 로그인 시 쿼리로 필요한 정보 프론트로 전달
- 애플과 카카오 모두 회원 가입 시, 1.0 릴리즈 기준에 맞추어 유저네임 한글 3글자로 제한했습니다.
- rT를 새로 발급하는 로직과 쿠키를 새로 굽는 로직 분리 및 리팩했습니다.

*알림*
- 로그인 이후에 expoToken PATCH할 API 새로 작성 및 테스트 작성했습니다.
- 다중기기는 슬랙에서 논의한대로 접속은 가능하되 최근에 접속한 기기에만 알림이 가도록 구현했습니다.

*탈퇴*
- 유저 탈퇴 시 애플 로그인의 경우 한번 재로그인을 요청하고, 이후 애플에 연동 해제하도록 구현했습니다.
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/login
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] 리다렉 할 때 쿼리로 필요한 정보 전달
- [x] issueNewToken과 쿠키 set 분리 및 리팩
- [x] expoToken patch API 새로 작성
- [x] 테스트 코드 작성
- [x] 다중기기 관련 논의 필요
- [x] 유저 탈퇴 시 애플 계정일 경우 연동 해제
- [x] 애플/카카오 로그인 유저 네임 길이 제한에 맞춰 수정

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#174 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
