### PR TITLE
feat: 완주한 돈길만 가져오기 API 작성

### DIFF
--- a/src/main/java/com/ceos/bankids/constant/ChallengeStatus.java
+++ b/src/main/java/com/ceos/bankids/constant/ChallengeStatus.java
@@ -7,15 +7,16 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ChallengeStatus implements EnumMapperType {
 
-    REJECTED(1L, 0L, "부모가 거절한 상태"),
-    ACHIEVED(2L, 0L, "돈길을 완전히 완주한 상태"),
-    FAILED(0L, 0L, "이자율 위험도에 걸려서 실패한 상태"),
-    PENDING(1L, 1L, "부모한테 제안한 상태"),
-    WALKING(1L, 2L, "부모한테 수락 받아서 걷고있는 상태");
+    REJECTED(1L, 0L, "부모가 거절한 상태", "rejected"),
+    ACHIEVED(2L, 0L, "돈길을 완전히 완주한 상태", "achieved"),
+    FAILED(0L, 0L, "이자율 위험도에 걸려서 실패한 상태", "failed"),
+    PENDING(1L, 1L, "부모한테 제안한 상태", "pending"),
+    WALKING(1L, 2L, "부모한테 수락 받아서 걷고있는 상태", "walking");
 
     private final Long isAchieved;
     private final Long status;
     private final String description;
+    private final String statusName;
 
     @Override
     public String getCode() {

--- a/src/main/java/com/ceos/bankids/controller/ChallengeController.java
+++ b/src/main/java/com/ceos/bankids/controller/ChallengeController.java
@@ -115,4 +115,16 @@ public class ChallengeController {
 
         return CommonResponse.onSuccess(kidWeekDTO);
     }
+
+    @ApiOperation(value = "완주한 돈길 리스트 가져오기")
+    @GetMapping(value = "/achieved", produces = "application/json; charset=utf-8")
+    public CommonResponse<List<ChallengeDTO>> getAchievedListChallenge(
+        @AuthenticationPrincipal User authUser, @RequestParam String status) {
+
+        log.info("api = 완주한 돈길 리스트 가져오기, user = {}", authUser.getUsername());
+        List<ChallengeDTO> challengeDTOList = challengeService.readAchievedChallenge(authUser,
+            status);
+
+        return CommonResponse.onSuccess(challengeDTOList);
+    }
 }

--- a/src/main/java/com/ceos/bankids/controller/ChallengeController.java
+++ b/src/main/java/com/ceos/bankids/controller/ChallengeController.java
@@ -119,11 +119,10 @@ public class ChallengeController {
     @ApiOperation(value = "완주한 돈길 리스트 가져오기")
     @GetMapping(value = "/achieved", produces = "application/json; charset=utf-8")
     public CommonResponse<List<ChallengeDTO>> getAchievedListChallenge(
-        @AuthenticationPrincipal User authUser, @RequestParam String status) {
+        @AuthenticationPrincipal User authUser) {
 
         log.info("api = 완주한 돈길 리스트 가져오기, user = {}", authUser.getUsername());
-        List<ChallengeDTO> challengeDTOList = challengeService.readAchievedChallenge(authUser,
-            status);
+        List<ChallengeDTO> challengeDTOList = challengeService.readAchievedChallenge(authUser);
 
         return CommonResponse.onSuccess(challengeDTOList);
     }

--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -63,6 +63,10 @@ public class Challenge extends AbstractTimestamp {
     private Long interestRate;
 
     @Column(nullable = false)
+    @ColumnDefault("false")
+    private Boolean isInterestPayment;
+
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Long successWeeks;
 
@@ -103,6 +107,7 @@ public class Challenge extends AbstractTimestamp {
         Long weekPrice,
         Long weeks,
         Long interestRate,
+        Boolean isInterestPayment,
         Long successWeeks,
         String filename,
         ChallengeCategory challengeCategory,
@@ -145,6 +150,7 @@ public class Challenge extends AbstractTimestamp {
         this.weekPrice = weekPrice;
         this.weeks = weeks;
         this.interestRate = interestRate;
+        this.isInterestPayment = isInterestPayment;
         this.successWeeks = successWeeks;
         this.fileName = filename;
         this.challengeCategory = challengeCategory;

--- a/src/main/java/com/ceos/bankids/dto/KidChallengeListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidChallengeListDTO.java
@@ -23,9 +23,6 @@ public class KidChallengeListDTO {
     @ApiModelProperty(example = "1")
     private Long kidId;
 
-    @ApiModelProperty(example = "string")
-    private String username;
-
     @ApiModelProperty(example = "true")
     private Boolean isFemale;
 
@@ -34,7 +31,6 @@ public class KidChallengeListDTO {
 
     public KidChallengeListDTO(User user, List<ChallengeDTO> challengeList) {
         this.kidId = user.getKid().getId();
-        this.username = user.getUsername();
         this.isFemale = user.getIsFemale();
         this.challengeList = challengeList;
     }

--- a/src/main/java/com/ceos/bankids/dto/KidListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidListDTO.java
@@ -13,8 +13,6 @@ public class KidListDTO {
 
     @ApiModelProperty(example = "1")
     Long kidId;
-    @ApiModelProperty(example = "주어랑")
-    String username;
     @ApiModelProperty(example = "true")
     Boolean isFemale;
     @ApiModelProperty(example = "1")
@@ -28,7 +26,6 @@ public class KidListDTO {
 
     public KidListDTO(User user) {
         this.kidId = user.getKid().getId();
-        this.username = user.getUsername();
         this.isFemale = user.getIsFemale();
         this.level = user.getKid().getLevel();
         this.savings = user.getKid().getSavings();

--- a/src/main/java/com/ceos/bankids/dto/KidListDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/KidListDTO.java
@@ -13,6 +13,8 @@ public class KidListDTO {
 
     @ApiModelProperty(example = "1")
     Long kidId;
+    @ApiModelProperty(example = "주어랑")
+    String username;
     @ApiModelProperty(example = "true")
     Boolean isFemale;
     @ApiModelProperty(example = "1")
@@ -26,6 +28,7 @@ public class KidListDTO {
 
     public KidListDTO(User user) {
         this.kidId = user.getKid().getId();
+        this.username = user.getUsername();
         this.isFemale = user.getIsFemale();
         this.level = user.getKid().getLevel();
         this.savings = user.getKid().getSavings();

--- a/src/main/java/com/ceos/bankids/service/ChallengeService.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeService.java
@@ -29,6 +29,6 @@ public interface ChallengeService {
 
     public KidWeekDTO readKidWeekInfo(User user, Long kidId);
 
-    public List<ChallengeDTO> readAchievedChallenge(User user, String status);
+    public List<ChallengeDTO> readAchievedChallenge(User user);
 
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeService.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeService.java
@@ -29,4 +29,6 @@ public interface ChallengeService {
 
     public KidWeekDTO readKidWeekInfo(User user, Long kidId);
 
+    public List<ChallengeDTO> readAchievedChallenge(User user, String status);
+
 }

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -266,8 +266,10 @@ public class ChallengeServiceImpl implements ChallengeService {
                         notificationController.achieveChallengeNotification(
                             challenge.getContractUser(), r);
                     }
-//                    challengeDTOList.add(new ChallengeDTO(r.getChallenge(), progressDTOList,
-//                        r.getChallenge().getComment()));
+                    if (challenge.getChallengeStatus() != achieved) {
+                        challengeDTOList.add(new ChallengeDTO(r.getChallenge(), progressDTOList,
+                            r.getChallenge().getComment()));
+                    }
                 } else if (r.getChallenge().getChallengeStatus() == failed) {
                     List<Progress> progressList = r.getChallenge().getProgressList();
                     List<ProgressDTO> progressDTOList = new ArrayList<>();

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -445,6 +445,24 @@ public class ChallengeServiceImpl implements ChallengeService {
         return new KidWeekDTO(kid.getKid(), weekDTO);
     }
 
+    // 완주한 돈길만 가져오기 API
+    @Transactional
+    @Override
+    public List<ChallengeDTO> readAchievedChallenge(User user, String status) {
+
+        List<Challenge> challengeList = challengeUserRepository.findByUserId(user.getId()).stream()
+            .map(ChallengeUser::getChallenge).filter(challenge -> Objects.equals(
+                challenge.getChallengeStatus().getStatusName(), status))
+            .collect(
+                Collectors.toList());
+        return challengeList.stream().map(challenge -> {
+            List<ProgressDTO> progressDTOList = challenge.getProgressList().stream()
+                .map(progress -> new ProgressDTO(progress, challenge)).collect(
+                    Collectors.toList());
+            return new ChallengeDTO(challenge, progressDTOList, null);
+        }).collect(Collectors.toList());
+    }
+
     private void userRoleValidation(User user, Boolean approveRole) {
         if (user.getIsKid() != approveRole) {
             throw new ForbiddenException(ErrorCode.USER_ROLE_ERROR.getErrorCode());

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -391,7 +391,6 @@ public class ChallengeServiceImpl implements ChallengeService {
             challengeRepository.save(challenge);
             progressDTOList = null;
         }
-        // Todo: 알림
         notificationController.notification(challenge, user);
         return new ChallengeDTO(challenge, progressDTOList, challenge.getComment());
     }
@@ -445,14 +444,15 @@ public class ChallengeServiceImpl implements ChallengeService {
         return new KidWeekDTO(kid.getKid(), weekDTO);
     }
 
+    // Todo: 후에 돈길 히스토리 추가되면 쿼리파라미터로 넘기기만 하면 작동되게 해놓
     // 완주한 돈길만 가져오기 API
     @Transactional
     @Override
-    public List<ChallengeDTO> readAchievedChallenge(User user, String status) {
+    public List<ChallengeDTO> readAchievedChallenge(User user) {
 
         List<Challenge> challengeList = challengeUserRepository.findByUserId(user.getId()).stream()
             .map(ChallengeUser::getChallenge).filter(challenge -> Objects.equals(
-                challenge.getChallengeStatus().getStatusName(), status))
+                challenge.getChallengeStatus(), achieved))
             .collect(
                 Collectors.toList());
         return challengeList.stream().map(challenge -> {

--- a/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ChallengeServiceImpl.java
@@ -233,7 +233,7 @@ public class ChallengeServiceImpl implements ChallengeService {
                     Long risk = 0L;
                     Long falseCnt = 0L;
                     if (interestRate == 10L) {
-                        risk = challenge.getWeeks();
+                        risk = 1000L;
                     } else if (interestRate == 20L) {
                         risk = 4L;
                     } else if (interestRate == 30L) {
@@ -266,8 +266,8 @@ public class ChallengeServiceImpl implements ChallengeService {
                         notificationController.achieveChallengeNotification(
                             challenge.getContractUser(), r);
                     }
-                    challengeDTOList.add(new ChallengeDTO(r.getChallenge(), progressDTOList,
-                        r.getChallenge().getComment()));
+//                    challengeDTOList.add(new ChallengeDTO(r.getChallenge(), progressDTOList,
+//                        r.getChallenge().getComment()));
                 } else if (r.getChallenge().getChallengeStatus() == failed) {
                     List<Progress> progressList = r.getChallenge().getProgressList();
                     List<ProgressDTO> progressDTOList = new ArrayList<>();
@@ -279,14 +279,6 @@ public class ChallengeServiceImpl implements ChallengeService {
                             progressDTOList.add(new ProgressDTO(progress, r.getChallenge()));
                         }
                     }
-                    challengeDTOList.add(
-                        new ChallengeDTO(r.getChallenge(), progressDTOList, r.getChallenge()
-                            .getComment()));
-                } else if (r.getChallenge().getChallengeStatus() == achieved) {
-                    List<Progress> progressList = r.getChallenge().getProgressList();
-                    List<ProgressDTO> progressDTOList = progressList.stream()
-                        .map(p -> new ProgressDTO(p, r.getChallenge())).collect(
-                            Collectors.toList());
                     challengeDTOList.add(
                         new ChallengeDTO(r.getChallenge(), progressDTOList, r.getChallenge()
                             .getComment()));


### PR DESCRIPTION
## 📝 PR Summary

* 기획 측 요청에 따라 완주한 돈길만 따로 받아오는 API 작성했습니다
* 해당 API가 생김에 따라 돈길 리스트 가져오기 API에서 완주 돈길은 빼고 가져옵니다
* 또, 프론트 측 요청에 따라 kidChallengeList DTO에서 kidId 추가 / kid의 username 삭제

#### 🌲 Working Branch

achievedChallengeSortAPI

### Related Issues

#172
