### PR TITLE
feat: 새로운 가족 참여시 푸시 알림

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/NotificationController.java
+++ b/src/main/java/com/ceos/bankids/controller/NotificationController.java
@@ -161,4 +161,5 @@ public class NotificationController {
         log.info("부모 유저 id = {}에게 유저 id = {}의 돈길 id = {} 돈길 실패 알림 전송", contractUser.getId(),
             challengeUser.getChallenge().getId(), challengeUser.getChallenge().getId());
     }
+
 }

--- a/src/main/java/com/ceos/bankids/controller/NotificationController.java
+++ b/src/main/java/com/ceos/bankids/controller/NotificationController.java
@@ -5,11 +5,13 @@ import com.ceos.bankids.constant.ChallengeStatus;
 import com.ceos.bankids.controller.request.AllSendNotificationRequest;
 import com.ceos.bankids.domain.Challenge;
 import com.ceos.bankids.domain.ChallengeUser;
+import com.ceos.bankids.domain.FamilyUser;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.repository.UserRepository;
 import com.ceos.bankids.service.ExpoNotificationServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import java.util.HashMap;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -162,4 +164,18 @@ public class NotificationController {
             challengeUser.getChallenge().getId(), challengeUser.getChallenge().getId());
     }
 
+    @Async
+    public void newFamilyUserNotification(User newFamilyUser, List<FamilyUser> familyUserList) {
+
+        String title = "가족그룹\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC66에 새로 참여했어요";
+        String notificationBody = "누가 가족그룹에 참여했는지 확인해요!\uD83D\uDCAB";
+        HashMap<String, Object> newMap = new HashMap<>();
+//        newMap.put("user", newFamilyUser.getId());
+        familyUserList.forEach(familyUser -> {
+            String token = familyUser.getUser().getExpoToken();
+            expoNotificationService.sendMessage(token, title, notificationBody, newMap);
+            log.info("기존 가족 구성원 id = {}에게 유저 id = {}의 가족 참여 알림 전송", familyUser.getUser().getId(),
+                newFamilyUser.getId());
+        });
+    }
 }

--- a/src/main/java/com/ceos/bankids/dto/FamilyDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/FamilyDTO.java
@@ -3,6 +3,7 @@ package com.ceos.bankids.dto;
 import com.ceos.bankids.domain.Family;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,6 +23,7 @@ public class FamilyDTO {
     private List<FamilyUserDTO> familyUserList;
 
 
+    @Builder
     public FamilyDTO(Family family, List<FamilyUserDTO> familyUserList) {
         this.id = family.getId();
         this.code = family.getCode();

--- a/src/main/java/com/ceos/bankids/dto/FamilyUserDTO.java
+++ b/src/main/java/com/ceos/bankids/dto/FamilyUserDTO.java
@@ -1,6 +1,6 @@
 package com.ceos.bankids.dto;
 
-import com.ceos.bankids.domain.User;
+import com.ceos.bankids.domain.FamilyUser;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -19,9 +19,9 @@ public class FamilyUserDTO {
     private Boolean isKid;
 
 
-    public FamilyUserDTO(User user) {
-        this.username = user.getUsername();
-        this.isFemale = user.getIsFemale();
-        this.isKid = user.getIsKid();
+    public FamilyUserDTO(FamilyUser familyUser) {
+        this.username = familyUser.getUser().getUsername();
+        this.isFemale = familyUser.getUser().getIsFemale();
+        this.isKid = familyUser.getUser().getIsKid();
     }
 }

--- a/src/main/java/com/ceos/bankids/repository/FamilyUserRepository.java
+++ b/src/main/java/com/ceos/bankids/repository/FamilyUserRepository.java
@@ -2,6 +2,7 @@ package com.ceos.bankids.repository;
 
 import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.FamilyUser;
+import com.ceos.bankids.domain.User;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface FamilyUserRepository extends JpaRepository<FamilyUser, Long> {
     public Optional<FamilyUser> findByUserId(Long id);
 
     public List<FamilyUser> findByFamily(Family family);
+
+    public List<FamilyUser> findByFamilyAndUserNot(Family family, User user);
 }

--- a/src/main/java/com/ceos/bankids/service/FamilyService.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyService.java
@@ -1,9 +1,7 @@
 package com.ceos.bankids.service;
 
-import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.FamilyDTO;
-import com.ceos.bankids.dto.FamilyUserDTO;
 import com.ceos.bankids.dto.KidListDTO;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -12,8 +10,6 @@ import org.springframework.stereotype.Service;
 public interface FamilyService {
 
     public FamilyDTO postNewFamily(User user);
-
-    public List<FamilyUserDTO> getFamilyUserList(Family family, User user);
 
     public FamilyDTO getFamily(User user);
 

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.service;
 
 import com.ceos.bankids.constant.ErrorCode;
+import com.ceos.bankids.controller.NotificationController;
 import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.FamilyUser;
 import com.ceos.bankids.domain.User;
@@ -28,6 +29,7 @@ public class FamilyServiceImpl implements FamilyService {
 
     private final FamilyRepository fRepo;
     private final FamilyUserRepository fuRepo;
+    private final NotificationController notificationController;
 
     @Override
     @Transactional
@@ -163,6 +165,8 @@ public class FamilyServiceImpl implements FamilyService {
             .family(newFamily.get())
             .build();
         fuRepo.save(newFamilyUser);
+
+        notificationController.newFamilyUserNotification(user, familyUserList);
 
         return FamilyDTO.builder()
             .family(newFamily.get())

--- a/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyServiceImpl.java
@@ -39,11 +39,16 @@ public class FamilyServiceImpl implements FamilyService {
             if (family.isEmpty()) {
                 throw new BadRequestException(ErrorCode.FAMILY_NOT_EXISTS.getErrorCode());
             }
-            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(
-                familyUser.get().getFamily(), user);
-            FamilyDTO familyDTO = new FamilyDTO(familyUser.get().getFamily(), familyUserDTOList);
+            List<FamilyUser> familyUserList = fuRepo.findByFamilyAndUserNot(family.get(), user);
 
-            return familyDTO;
+            return FamilyDTO.builder()
+                .family(family.get())
+                .familyUserList(
+                    familyUserList
+                        .stream()
+                        .map(FamilyUserDTO::new)
+                        .collect(Collectors.toList())
+                ).build();
         } else {
             String newFamilyCode = UUID.randomUUID().toString();
             Family newFamily = Family.builder()
@@ -57,24 +62,11 @@ public class FamilyServiceImpl implements FamilyService {
                 .build();
             fuRepo.save(newFamilyUser);
 
-            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(newFamily, user);
-            FamilyDTO familyDTO = new FamilyDTO(newFamily, familyUserDTOList);
-
-            return familyDTO;
+            return FamilyDTO.builder()
+                .family(newFamily)
+                .familyUserList(List.of())
+                .build();
         }
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<FamilyUserDTO> getFamilyUserList(Family family, User user) {
-        List<FamilyUser> familyUser = fuRepo.findByFamily(family);
-
-        List<FamilyUserDTO> userDTOList = familyUser.stream().map(FamilyUser::getUser)
-            .filter(u -> !u.getId().equals(user.getId()))
-            .map(FamilyUserDTO::new)
-            .collect(Collectors.toList());
-
-        return userDTOList;
     }
 
     @Override
@@ -86,12 +78,21 @@ public class FamilyServiceImpl implements FamilyService {
             if (family.isEmpty()) {
                 throw new BadRequestException(ErrorCode.FAMILY_NOT_EXISTS.getErrorCode());
             }
-            List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(family.get(), user);
-            FamilyDTO familyDTO = new FamilyDTO(family.get(), familyUserDTOList);
-            return familyDTO;
+            List<FamilyUser> familyUserList = fuRepo.findByFamilyAndUserNot(family.get(), user);
+
+            return FamilyDTO.builder()
+                .family(family.get())
+                .familyUserList(
+                    familyUserList
+                        .stream()
+                        .map(FamilyUserDTO::new)
+                        .collect(Collectors.toList())
+                ).build();
         } else {
-            FamilyDTO familyDTO = new FamilyDTO(new Family(), new ArrayList<>());
-            return familyDTO;
+            return FamilyDTO.builder()
+                .family(new Family())
+                .familyUserList(List.of())
+                .build();
         }
     }
 
@@ -163,10 +164,14 @@ public class FamilyServiceImpl implements FamilyService {
             .build();
         fuRepo.save(newFamilyUser);
 
-        List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(newFamily.get(), user);
-        FamilyDTO familyDTO = new FamilyDTO(newFamily.get(), familyUserDTOList);
-
-        return familyDTO;
+        return FamilyDTO.builder()
+            .family(newFamily.get())
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
     }
 
     @Override
@@ -183,14 +188,19 @@ public class FamilyServiceImpl implements FamilyService {
         }
         fuRepo.delete(familyUser.get());
 
-        List<FamilyUserDTO> familyUserDTOList = getFamilyUserList(family, user);
-        FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
-
-        if (familyUserDTOList.size() == 0) {
+        List<FamilyUser> familyUserList = fuRepo.findByFamilyAndUserNot(family, user);
+        if (familyUserList.size() == 0) {
             fRepo.delete(family);
         }
-        
-        return familyDTO;
+
+        return FamilyDTO.builder()
+            .family(family)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
     }
 
 

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -2,6 +2,7 @@ package com.ceos.bankids.unit.controller;
 
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.FamilyController;
+import com.ceos.bankids.controller.NotificationController;
 import com.ceos.bankids.controller.request.FamilyRequest;
 import com.ceos.bankids.domain.Family;
 import com.ceos.bankids.domain.FamilyUser;
@@ -65,11 +66,14 @@ public class FamilyControllerTest {
             Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -119,11 +123,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -168,11 +175,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -239,11 +249,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService,
@@ -282,11 +295,14 @@ public class FamilyControllerTest {
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(null));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService,
@@ -336,11 +352,14 @@ public class FamilyControllerTest {
             Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -388,11 +407,14 @@ public class FamilyControllerTest {
             Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -440,11 +462,14 @@ public class FamilyControllerTest {
             Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -520,11 +545,14 @@ public class FamilyControllerTest {
             Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -574,11 +602,14 @@ public class FamilyControllerTest {
             Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -608,11 +639,14 @@ public class FamilyControllerTest {
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
             Optional.ofNullable(null));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -663,11 +697,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -727,11 +764,14 @@ public class FamilyControllerTest {
         familyUser1.setFamily(family2);
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -786,11 +826,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -876,11 +919,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -955,11 +1001,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1059,11 +1108,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1138,11 +1190,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1192,11 +1247,14 @@ public class FamilyControllerTest {
         FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(null));
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1269,11 +1327,14 @@ public class FamilyControllerTest {
             .thenReturn(Optional.ofNullable(null));
         familyUser1.setFamily(family2);
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1328,11 +1389,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1405,11 +1469,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService,
@@ -1466,11 +1533,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
         Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
             .thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1527,11 +1597,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(null));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1573,11 +1646,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService
@@ -1619,11 +1695,14 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         FamilyController familyController = new FamilyController(
             familyService, challengeService

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -117,6 +117,8 @@ public class FamilyControllerTest {
             Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -129,10 +131,14 @@ public class FamilyControllerTest {
         CommonResponse<FamilyDTO> result = familyController.postFamily(user1);
 
         // then
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .filter(u -> !u.getId().equals(1L))
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
 
@@ -160,6 +166,8 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(null));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -182,9 +190,14 @@ public class FamilyControllerTest {
         Assertions.assertEquals(family, fCaptor.getValue());
         Assertions.assertEquals(familyUser1, fuCaptor.getValue());
 
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
 
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
@@ -224,6 +237,8 @@ public class FamilyControllerTest {
             Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
         Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -237,9 +252,14 @@ public class FamilyControllerTest {
         CommonResponse<FamilyDTO> result = familyController.getFamily(user1);
 
         // then
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family, familyUserDTOList);
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
 
@@ -664,10 +684,17 @@ public class FamilyControllerTest {
         Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
         Assertions.assertEquals(familyUser1, fuCaptor.getValue());
 
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
 
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
 
@@ -698,6 +725,8 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(null));
         familyUser1.setFamily(family2);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -717,10 +746,14 @@ public class FamilyControllerTest {
         Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
         Assertions.assertEquals(familyUser1, fuCaptor.getValue());
 
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
-
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
 
@@ -920,6 +953,8 @@ public class FamilyControllerTest {
             .thenReturn(Optional.ofNullable(null));
         familyUser1.setFamily(family2);
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -939,10 +974,14 @@ public class FamilyControllerTest {
         Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
         Assertions.assertEquals(familyUser1, fuCaptor.getValue());
 
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
-
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
 
@@ -1097,6 +1136,8 @@ public class FamilyControllerTest {
             .thenReturn(Optional.ofNullable(null));
         familyUser1.setFamily(family2);
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -1116,10 +1157,14 @@ public class FamilyControllerTest {
         Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
         Assertions.assertEquals(familyUser1, fuCaptor.getValue());
 
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
-
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
 
@@ -1281,6 +1326,8 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -1297,9 +1344,14 @@ public class FamilyControllerTest {
         Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
         Assertions.assertEquals(familyUser1, fuCaptor.getValue());
 
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
 
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
@@ -1351,6 +1403,8 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -1368,9 +1422,14 @@ public class FamilyControllerTest {
         Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
         Assertions.assertEquals(familyUser1, fuCaptor.getValue());
 
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
 
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
@@ -1405,6 +1464,8 @@ public class FamilyControllerTest {
         Mockito.when(mockFamilyUserRepository.findByUserId(1L))
             .thenReturn(Optional.ofNullable(familyUser1));
         Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
 
         // when
         FamilyServiceImpl familyService = new FamilyServiceImpl(
@@ -1425,10 +1486,14 @@ public class FamilyControllerTest {
         Mockito.verify(mockFamilyRepository, Mockito.times(1)).delete(fCaptor.capture());
         Assertions.assertEquals(family2, fCaptor.getValue());
 
-        List<FamilyUserDTO> familyUserDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .map(FamilyUserDTO::new).collect(Collectors.toList());
-        FamilyDTO familyDTO = new FamilyDTO(family2, familyUserDTOList);
-
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
         Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
 

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.ceos.bankids.unit.controller;
 
 import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.NotificationController;
 import com.ceos.bankids.controller.UserController;
 import com.ceos.bankids.controller.request.ExpoRequest;
 import com.ceos.bankids.controller.request.FamilyRequest;
@@ -1014,6 +1015,8 @@ public class UserControllerTest {
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
@@ -1024,7 +1027,8 @@ public class UserControllerTest {
         );
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         ChallengeServiceImpl challengeService = null;
         KidBackupServiceImpl kidBackupService = null;
@@ -1118,6 +1122,8 @@ public class UserControllerTest {
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
@@ -1128,7 +1134,8 @@ public class UserControllerTest {
         );
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         ChallengeServiceImpl challengeService = null;
         KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
@@ -1220,6 +1227,8 @@ public class UserControllerTest {
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
@@ -1230,7 +1239,8 @@ public class UserControllerTest {
         );
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         KidBackupServiceImpl kidBackupService = null;
@@ -1341,6 +1351,8 @@ public class UserControllerTest {
         KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
         ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
         JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
 
         // when
         UserServiceImpl userService = new UserServiceImpl(
@@ -1351,7 +1363,8 @@ public class UserControllerTest {
         );
         FamilyServiceImpl familyService = new FamilyServiceImpl(
             mockFamilyRepository,
-            mockFamilyUserRepository
+            mockFamilyUserRepository,
+            mockNotificationController
         );
         ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
         KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);


### PR DESCRIPTION
## 📝 PR Summary
- 일단 리팩할 때 한번에 하려고 기존에 짜둔 로직이랑 최대한 일치하게 작성했습니다.
- HashMap에 별다른 내용 담지 않고 알림 전송하도록 해두었습니다.
- 가족 리스트 가져오기 메소드 리팩했습니다.
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/newFamilyUserNotification
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- 가족 관련 푸시 알림
- 가족이 아무도 없을 때 초대 장려 알림은 1.0 릴리즈 이후 작성
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#178 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
