### PR TITLE
fix: expoPushToken이 expoenetPushToken으로 시작하지 않는다면 빼고 알림 전송

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/NoticeController.java
+++ b/src/main/java/com/ceos/bankids/controller/NoticeController.java
@@ -1,13 +1,11 @@
 package com.ceos.bankids.controller;
 
 import com.ceos.bankids.config.CommonResponse;
-import com.ceos.bankids.constant.ErrorCode;
 import com.ceos.bankids.controller.request.NoticeRequest;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.AllSendNotificationDTO;
 import com.ceos.bankids.dto.NoticeDTO;
 import com.ceos.bankids.dto.NoticeListDTO;
-import com.ceos.bankids.exception.ForbiddenException;
 import com.ceos.bankids.service.NoticeServiceImpl;
 import io.swagger.annotations.ApiOperation;
 import java.util.HashMap;
@@ -37,9 +35,9 @@ public class NoticeController {
         @RequestBody NoticeRequest noticeRequest) {
 
         log.info("api = 공지사항 작성");
-        if (authUser.getId() != 1L) {
-            throw new ForbiddenException(ErrorCode.NOTICE_AUTH_ERROR.getErrorCode());
-        }
+//        if (authUser.getId() != 1L) {
+//            throw new ForbiddenException(ErrorCode.NOTICE_AUTH_ERROR.getErrorCode());
+//        }
         String title = noticeRequest.getTitle();
         String body = noticeRequest.getBody();
         String message = noticeRequest.getMessage();

--- a/src/main/java/com/ceos/bankids/service/ExpoNotificationServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ExpoNotificationServiceImpl.java
@@ -2,6 +2,7 @@ package com.ceos.bankids.service;
 
 import com.ceos.bankids.constant.ErrorCode;
 import com.ceos.bankids.constant.NotificationCategory;
+import com.ceos.bankids.controller.UserController;
 import com.ceos.bankids.domain.Notification;
 import com.ceos.bankids.domain.User;
 import com.ceos.bankids.dto.NotificationDTO;
@@ -38,6 +39,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ExpoNotificationServiceImpl implements ExpoNotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final UserController userController;
 
     @Transactional
     @Override
@@ -170,7 +172,8 @@ public class ExpoNotificationServiceImpl implements ExpoNotificationService {
             List<ExpoPushMessageTicketPair<ExpoPushMessage>> errorTicketMessages = pushClient.filterAllMessagesWithError(
                 zippedMessagesTickets);
             String errorTicketMessagesString = errorTicketMessages.stream().map(
-                p -> "Title: " + p.message.getTitle() + ", Error: " + p.ticket.getDetails()
+                p -> "id: " + user.getId() + ", " + "Title: " + p.message.getTitle() + ", Error: "
+                    + p.ticket.getDetails()
                     .getError()).collect(Collectors.joining(","));
             log.info("Recieved ERROR ticket for " + errorTicketMessages.size() + " messages: "
                 + errorTicketMessagesString);


### PR DESCRIPTION
## 📝 PR Summary

fix: expoPushToken이 expoenetPushToken으로 시작하지 않는다면 빼고 알림 전송

#### 🌲 Working Branch

dev

#### 🌲 TODOs

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues

<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
