### PR TITLE
feat: refresh API aT 사용하는 것으로 변경

### DIFF
--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -75,7 +75,7 @@ public class UserController {
         User user = userService.getUserByRefreshToken(tokenRequest.getAccessToken());
         LoginDTO loginDTO = userService.issueNewTokens(user, user.getProvider());
 
-        userService.setNewCookie(user, response);
+//        userService.setNewCookie(user, response);
         return CommonResponse.onSuccess(loginDTO);
     }
 
@@ -148,7 +148,7 @@ public class UserController {
         log.info("api = 유저 엑스포 토큰 등록, user = {}", authUser.getUsername());
         User user = userService.updateUserExpoToken(authUser, expoRequest);
 
-        userService.setNewCookie(user, response);
+//        userService.setNewCookie(user, response);
         return CommonResponse.onSuccess(null);
     }
 

--- a/src/main/java/com/ceos/bankids/controller/UserController.java
+++ b/src/main/java/com/ceos/bankids/controller/UserController.java
@@ -3,6 +3,7 @@ package com.ceos.bankids.controller;
 import com.ceos.bankids.config.CommonResponse;
 import com.ceos.bankids.controller.request.ExpoRequest;
 import com.ceos.bankids.controller.request.FamilyRequest;
+import com.ceos.bankids.controller.request.TokenRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.controller.request.WithdrawalRequest;
 import com.ceos.bankids.domain.User;
@@ -29,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -68,11 +68,11 @@ public class UserController {
     @ApiOperation(value = "토큰 리프레시")
     @PatchMapping(value = "/refresh", produces = "application/json; charset=utf-8")
     @ResponseBody
-    public CommonResponse<LoginDTO> refreshUserToken(
-        @CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
+    public CommonResponse<LoginDTO> refreshUserToken(@Valid @RequestBody TokenRequest tokenRequest,
+        HttpServletResponse response) {
 
         log.info("api = 토큰 리프레시");
-        User user = userService.getUserByRefreshToken(refreshToken);
+        User user = userService.getUserByRefreshToken(tokenRequest.getAccessToken());
         LoginDTO loginDTO = userService.issueNewTokens(user, user.getProvider());
 
         userService.setNewCookie(user, response);

--- a/src/main/java/com/ceos/bankids/controller/request/TokenRequest.java
+++ b/src/main/java/com/ceos/bankids/controller/request/TokenRequest.java
@@ -1,0 +1,25 @@
+package com.ceos.bankids.controller.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class TokenRequest {
+
+    @ApiModelProperty(example = "asdfasdfasdf")
+    @NotNull(message = "accessToken may not be null")
+    private String accessToken;
+}

--- a/src/main/java/com/ceos/bankids/service/UserService.java
+++ b/src/main/java/com/ceos/bankids/service/UserService.java
@@ -9,7 +9,6 @@ import com.ceos.bankids.dto.MyPageDTO;
 import com.ceos.bankids.dto.OptInDTO;
 import com.ceos.bankids.dto.UserDTO;
 import com.ceos.bankids.dto.oauth.KakaoUserDTO;
-import javax.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,7 +23,7 @@ public interface UserService {
 
     public LoginDTO issueNewTokens(User user, String provider);
 
-    public void setNewCookie(User user, HttpServletResponse response);
+//    public void setNewCookie(User user, HttpServletResponse response);
 
     public MyPageDTO getUserInformation(User user);
 

--- a/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/UserServiceImpl.java
@@ -24,7 +24,6 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Optional;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -163,17 +162,17 @@ public class UserServiceImpl implements UserService {
         return loginDTO;
     }
 
-    @Override
-    @Transactional
-    public void setNewCookie(User user, HttpServletResponse response) {
-        Cookie cookie = new Cookie("refreshToken", user.getRefreshToken());
-        cookie.setMaxAge(14 * 24 * 60 * 60);
-        cookie.setSecure(true);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-
-        response.addCookie(cookie);
-    }
+//    @Override
+//    @Transactional
+//    public void setNewCookie(User user, HttpServletResponse response) {
+//        Cookie cookie = new Cookie("refreshToken", user.getRefreshToken());
+//        cookie.setMaxAge(14 * 24 * 60 * 60);
+//        cookie.setSecure(true);
+//        cookie.setHttpOnly(true);
+//        cookie.setPath("/");
+//
+//        response.addCookie(cookie);
+//    }
 
     @Override
     @Transactional

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import com.ceos.bankids.controller.NotificationController;
 import com.ceos.bankids.controller.UserController;
 import com.ceos.bankids.controller.request.ExpoRequest;
 import com.ceos.bankids.controller.request.FamilyRequest;
+import com.ceos.bankids.controller.request.TokenRequest;
 import com.ceos.bankids.controller.request.UserTypeRequest;
 import com.ceos.bankids.controller.request.WithdrawalRequest;
 import com.ceos.bankids.domain.Family;
@@ -571,7 +572,7 @@ public class UserControllerTest {
             slackService,
             notificationService
         );
-        CommonResponse result = userController.refreshUserToken("rT", response);
+        CommonResponse result = userController.refreshUserToken(new TokenRequest("rT"), response);
 
         // then
         LoginDTO loginDTO = new LoginDTO(false, "aT", user.getProvider());
@@ -638,7 +639,7 @@ public class UserControllerTest {
             notificationService
         );
 
-        CommonResponse result = userController.refreshUserToken("rT", response);
+        CommonResponse result = userController.refreshUserToken(new TokenRequest("rT"), response);
 
         // then
         LoginDTO loginDTO = new LoginDTO(true, "aT", 1L, user.getProvider());
@@ -701,7 +702,7 @@ public class UserControllerTest {
             notificationService
         );
 
-        CommonResponse result = userController.refreshUserToken("rT", response);
+        CommonResponse result = userController.refreshUserToken(new TokenRequest("rT"), response);
 
         // then
         LoginDTO loginDTO = new LoginDTO(null, "aT", user.getProvider());


### PR DESCRIPTION
## 📝 PR Summary
- 쿠키를 사용하지 않도록 바뀐 로그인 로직에 맞추어 API 수정했습니다.
- 이후 쿠키를 다시 사용할 것을 고려해 쿠키 굽는 함수 호출은 주석 처리했습니다.
- 테스트 코드 작성했습니다.
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
feature/aTrefresh
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] refresh API 수정
- [x] 기존 코드에서 사용하지 않는 부분 주석 처리
- [x] 테스트 코드 작성
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#221 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
