### PR TITLE
refactor: 유저, 가족 API 테스트 코드 리팩토링

### DIFF
--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -1,1717 +1,1905 @@
-//package com.ceos.bankids.unit.controller;
-//
-//import com.ceos.bankids.config.CommonResponse;
-//import com.ceos.bankids.domain.Family;
-//import com.ceos.bankids.domain.FamilyUser;
-//import com.ceos.bankids.domain.Kid;
-//import com.ceos.bankids.domain.Parent;
-//import com.ceos.bankids.domain.User;
-//import com.ceos.bankids.dto.FamilyDTO;
-//import com.ceos.bankids.dto.FamilyUserDTO;
-//import com.ceos.bankids.dto.KidListDTO;
-//import com.ceos.bankids.exception.BadRequestException;
-//import com.ceos.bankids.exception.ForbiddenException;
-//import com.ceos.bankids.mapper.FamilyController;
-//import com.ceos.bankids.mapper.NotificationMapper;
-//import FamilyRequest;
-//import com.ceos.bankids.repository.FamilyRepository;
-//import com.ceos.bankids.repository.FamilyUserRepository;
-//import com.ceos.bankids.service.ChallengeServiceImpl;
-//import com.ceos.bankids.service.FamilyServiceImpl;
-//import com.ceos.bankids.service.FamilyUserServiceImpl;
-//import java.util.ArrayList;
-//import java.util.List;
-//import java.util.Optional;
-//import java.util.stream.Collectors;
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.Mockito;
-//
-//public class FamilyControllerTest {
-//
-//    @Test
-//    @DisplayName("생성 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
-//    public void testIfFamilyExistedButDeletedWhenPostThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        Family family = Family.builder().id(1L).code("code").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-//        familyUserList.add(familyUser1);
-//        familyUserList.add(familyUser2);
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
-//            Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.postFamily(user1);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("생성 시 기존 가족 있을 때, 에러 처리 하는지 확인")
-//    public void testIfFamilyExistThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        Family family = Family.builder().id(1L).code("code").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-//        familyUserList.add(familyUser1);
-//        familyUserList.add(familyUser2);
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
-//            Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.postFamily(user1);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("생성 시 기존 가족 없을 때, 가족 생성 후 정보 반환하는지 확인")
-//    public void testIfFamilyNotExistThenPostAndReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family = Family.builder().code("code").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(null));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.postFamily(user1);
-//        String code = result.getData().getCode();
-//        family.setCode(code);
-//
-//        // then
-//        ArgumentCaptor<Family> fCaptor = ArgumentCaptor.forClass(Family.class);
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        Mockito.verify(mockFamilyRepository, Mockito.times(1)).save(fCaptor.capture());
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
-//
-//        Assertions.assertEquals(family, fCaptor.getValue());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("조회 시 기존 가족 있을 때, 가족 정보 반환하는지 확인")
-//    public void testIfFamilyExistThenReturnGetResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        Family family = Family.builder().id(1L).code("code").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-//        familyUserList.add(familyUser2);
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
-//            Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.getFamily(user1);
-//
-//        // then
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("조회 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
-//    public void testIfFamilyExistedButDeletedWhenGetThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        Family family = Family.builder().id(1L).code("code").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-//        familyUserList.add(familyUser1);
-//        familyUserList.add(familyUser2);
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
-//            Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.getFamily(user1);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("아이 조회 시 자녀일 경우, 에러 처리 하는지 확인")
-//    public void testIfAKidTryToGetKidListThenThrowForbiddenException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        Family family = Family.builder().id(1L).code("code").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-//        familyUserList.add(familyUser1);
-//        familyUserList.add(familyUser2);
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
-//            Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(ForbiddenException.class, () -> {
-//            familyController.getFamilyKidList(user1);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("아이 조회 시 결과 있을 때, 아이 리스트 정보 가나다순으로 반환하는지 확인")
-//    public void testIfFamilyExistThenReturnKidListResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("성우")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("민준")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("어진")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        User user4 = User.builder()
-//            .id(4L)
-//            .username("규진")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        Kid kid2 = Kid.builder().level(1L).user(user2).build();
-//        Kid kid3 = Kid.builder().level(2L).user(user3).build();
-//        Kid kid4 = Kid.builder().level(3L).user(user4).build();
-//        user2.setKid(kid2);
-//        user3.setKid(kid3);
-//        user4.setKid(kid4);
-//        Family family = Family.builder().id(1L).code("code").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family).build();
-//        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-//        familyUserList.add(familyUser1);
-//        familyUserList.add(familyUser4);
-//        familyUserList.add(familyUser2);
-//        familyUserList.add(familyUser3);
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
-//            Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<List<KidListDTO>> result = familyController.getFamilyKidList(user1);
-//
-//        // then
-//        List<KidListDTO> kidListDTOList = familyUserList.stream().map(FamilyUser::getUser)
-//            .filter(User::getIsKid).map(KidListDTO::new).collect(
-//                Collectors.toList());
-//        Assertions.assertEquals(CommonResponse.onSuccess(kidListDTOList), result);
-//    }
-//
-//    @Test
-//    @DisplayName("아이 조회 시 결과 없을 때, 빈 리스트 반환하는지 확인")
-//    public void testIfFamilyExistButNotKidThenReturnEmptyList() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        Family family = Family.builder().id(1L).code("code").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
-//        familyUserList.add(familyUser1);
-//        familyUserList.add(familyUser2);
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
-//            Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<List<KidListDTO>> result = familyController.getFamilyKidList(user1);
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(new ArrayList()), result);
-//    }
-//
-//    @Test
-//    @DisplayName("아이 조회 시 가족 없을 때, 에러 처리 하는지 확인")
-//    public void testIfFamilyNotExistThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
-//            Optional.ofNullable(null));
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.getFamilyKidList(user1);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("가족 참여 시 기존 가족 있을 때, 삭제 후 새 가족 참여하는지 확인")
-//    public void testIfLeaveFamilyAndJoinNewFamilyThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family1 = Family.builder().id(1L).code("code").build();
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family1).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser2);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(family2));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.postFamilyUser(user1, familyRequest);
-//        String code = result.getData().getCode();
-//        family1.setCode(code);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//        familyUser1.setFamily(family2);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
-//            .thenReturn(familyUserList);
-//
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family2)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("가족 참여 시 기존 가족 없을 때, 새 가족 참여하는지 확인")
-//    public void testIfJoinNewFamilyThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(family2));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        familyUser1.setFamily(family2);
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.postFamilyUser(user1, familyRequest);
-//        String code = result.getData().getCode();
-//        family2.setCode(code);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        familyUser1.setFamily(family2);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family2)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("가족 참여 시 해당 가족 구성원일 때, 에러 처리 하는지 확인")
-//    public void testIfUserIsAlreadyInFamilyThenThrowForbiddenException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser1);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(family2));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(ForbiddenException.class, () -> {
-//            familyController.postFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("엄마로 가족 참여 시 엄마가 이미 존재할 때, 에러 처리 하는지 확인")
-//    public void testIfUserIsMomAndMomAlreadyInFamilyThenThrowForbiddenException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(false)
-//            .build();
-//        User user4 = User.builder()
-//            .id(4L)
-//            .username("user4")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(false)
-//            .build();
-//        User user5 = User.builder()
-//            .id(5L)
-//            .username("user5")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family1 = Family.builder().id(1L).code("code").build();
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family1).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
-//        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser2);
-//        familyUserList.add(familyUser3);
-//        familyUserList.add(familyUser4);
-//        familyUserList.add(familyUser5);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
-//        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(family2));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(ForbiddenException.class, () -> {
-//            familyController.postFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("엄마로 가족 참여 시 엄마 존재하지 않을 때, 결과 반환 하는지 확인")
-//    public void testIfUserIsMomAndMomNotInFamilyThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(false)
-//            .build();
-//        User user4 = User.builder()
-//            .id(4L)
-//            .username("user4")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(false)
-//            .build();
-//        User user5 = User.builder()
-//            .id(5L)
-//            .username("user5")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
-//        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser3);
-//        familyUserList.add(familyUser4);
-//        familyUserList.add(familyUser5);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(family2));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        familyUser1.setFamily(family2);
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.postFamilyUser(user1, familyRequest);
-//        String code = result.getData().getCode();
-//        family2.setCode(code);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        familyUser1.setFamily(family2);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family2)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("아빠로 가족 참여 시 아빠가 이미 존재할 때, 에러 처리 하는지 확인")
-//    public void testIfUserIsDadAndDadAlreadyInFamilyThenThrowForbiddenException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(false)
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(false)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        User user4 = User.builder()
-//            .id(4L)
-//            .username("user4")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(false)
-//            .build();
-//        User user5 = User.builder()
-//            .id(5L)
-//            .username("user5")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family1 = Family.builder().id(1L).code("code").build();
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family1).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
-//        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser2);
-//        familyUserList.add(familyUser3);
-//        familyUserList.add(familyUser4);
-//        familyUserList.add(familyUser5);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
-//        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(family2));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(ForbiddenException.class, () -> {
-//            familyController.postFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("아빠로 가족 참여 시 아빠 존재하지 않을 때, 결과 반환 하는지 확인")
-//    public void testIfUserIsDadAndDadNotInFamilyThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(false)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        User user4 = User.builder()
-//            .id(4L)
-//            .username("user4")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(false)
-//            .build();
-//        User user5 = User.builder()
-//            .id(5L)
-//            .username("user5")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
-//        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser3);
-//        familyUserList.add(familyUser4);
-//        familyUserList.add(familyUser5);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(family2));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        familyUser1.setFamily(family2);
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.postFamilyUser(user1, familyRequest);
-//        String code = result.getData().getCode();
-//        family2.setCode(code);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        familyUser1.setFamily(family2);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family2)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("가족 참여 시 참여하려는 가족이 없을 때, 에러 처리 하는지 확인")
-//    public void testIfFamilyToJoinNotExistThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(false)
-//            .build();
-//
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(null));
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(null));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.postFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("예외) 부모로 가족 참여 시 성별 선택 안되었을 때, 에러 처리 하는지 확인")
-//    public void testIfUserIsParentButSexUnknownThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(null)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//        User user4 = User.builder()
-//            .id(4L)
-//            .username("user4")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(false)
-//            .build();
-//        User user5 = User.builder()
-//            .id(5L)
-//            .username("user5")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(true)
-//            .build();
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
-//        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser3);
-//        familyUserList.add(familyUser4);
-//        familyUserList.add(familyUser5);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findByCode("test"))
-//            .thenReturn(Optional.ofNullable(family2));
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        familyUser1.setFamily(family2);
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.postFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("부모 가족 나가기 성공 시, 결과 반환 하는지 확인")
-//    public void testIfParentFamilyUserDeleteSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(null)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser3);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family2)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("자녀 가족 나가기 성공 시, 결과 반환 하는지 확인")
-//    public void testIfKidFamilyUserDeleteSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(null)
-//            .build();
-//        User user3 = User.builder()
-//            .id(3L)
-//            .username("user3")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(true)
-//            .build();
-//
-//        Kid kid = Kid.builder()
-//            .id(1L)
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(1L)
-//            .user(user1)
-//            .build();
-//
-//        user1.setKid(kid);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser3);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family2)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 가족 나가기 성공 후 가족 없어 삭제 성공 시, 결과 반환 하는지 확인")
-//    public void testIfFamilyUserDeleteSucceedAndFamilyDeleteSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(null)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
-//            .thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
-//
-//        // then
-//        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
-//        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
-//
-//        ArgumentCaptor<Family> fCaptor = ArgumentCaptor.forClass(Family.class);
-//        Mockito.verify(mockFamilyRepository, Mockito.times(1)).delete(fCaptor.capture());
-//        Assertions.assertEquals(family2, fCaptor.getValue());
-//
-//        FamilyDTO familyDTO = FamilyDTO.builder()
-//            .family(family2)
-//            .familyUserList(
-//                familyUserList
-//                    .stream()
-//                    .map(FamilyUserDTO::new)
-//                    .collect(Collectors.toList())
-//            ).build();
-//        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저가 가입된 가족이 없는 경우, 에러 처리 하는지 확인")
-//    public void testIfFamilyUserDeleteFailBecauseFamilyUserNotExistThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(null)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.deleteFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("자녀가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
-//    public void testIfKidFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(true)
-//            .isFemale(null)
-//            .build();
-//
-//        Kid kid = Kid.builder()
-//            .id(1L)
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(1L)
-//            .user(user1)
-//            .build();
-//
-//        user1.setKid(kid);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("code");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.deleteFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("부모가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
-//    public void testIfParentFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .isKid(false)
-//            .isFemale(null)
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//
-//        user1.setParent(parent);
-//
-//        Family family2 = Family.builder().id(2L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        FamilyRequest familyRequest = new FamilyRequest("code");
-//
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
-//        NotificationMapper mockNotificationMapper = Mockito.mock(
-//            NotificationMapper.class);
-//
-//        // when
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(
-//            mockFamilyRepository
-//        );
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository
-//        );
-//        FamilyController familyController = new FamilyController(
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            mockNotificationMapper
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            familyController.deleteFamilyUser(user1, familyRequest);
-//        });
-//    }
-//
-//}
+package com.ceos.bankids.unit.controller;
+
+import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.FamilyController;
+import com.ceos.bankids.controller.request.FamilyRequest;
+import com.ceos.bankids.domain.Family;
+import com.ceos.bankids.domain.FamilyUser;
+import com.ceos.bankids.domain.Kid;
+import com.ceos.bankids.domain.Parent;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.FamilyDTO;
+import com.ceos.bankids.dto.FamilyUserDTO;
+import com.ceos.bankids.dto.KidListDTO;
+import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.exception.ForbiddenException;
+import com.ceos.bankids.mapper.FamilyMapper;
+import com.ceos.bankids.mapper.NotificationMapper;
+import com.ceos.bankids.repository.FamilyRepository;
+import com.ceos.bankids.repository.FamilyUserRepository;
+import com.ceos.bankids.repository.NotificationRepository;
+import com.ceos.bankids.service.ChallengeServiceImpl;
+import com.ceos.bankids.service.ChallengeUserServiceImpl;
+import com.ceos.bankids.service.ExpoNotificationServiceImpl;
+import com.ceos.bankids.service.FamilyServiceImpl;
+import com.ceos.bankids.service.FamilyUserServiceImpl;
+import com.ceos.bankids.service.KidServiceImpl;
+import com.ceos.bankids.service.ParentServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class FamilyControllerTest {
+
+    @Test
+    @DisplayName("생성 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
+    public void testIfFamilyExistedButDeletedWhenPostThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.postNewFamily(user1);
+        });
+    }
+
+    @Test
+    @DisplayName("생성 시 기존 가족 있을 때, 에러 처리 하는지 확인")
+    public void testIfFamilyExistThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.postNewFamily(user1);
+        });
+    }
+
+    @Test
+    @DisplayName("생성 시 기존 가족 없을 때, 가족 생성 후 정보 반환하는지 확인")
+    public void testIfFamilyNotExistThenPostAndReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+
+        Family family = Family.builder().code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(null));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.postNewFamily(user1);
+        String code = result.getData().getCode();
+        family.setCode(code);
+
+        // then
+        ArgumentCaptor<Family> fCaptor = ArgumentCaptor.forClass(Family.class);
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        Mockito.verify(mockFamilyRepository, Mockito.times(1)).save(fCaptor.capture());
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
+
+        Assertions.assertEquals(family, fCaptor.getValue());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
+
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("조회 시 기존 가족 있을 때, 가족 정보 반환하는지 확인")
+    public void testIfFamilyExistThenReturnGetResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser2);
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.getFamily(user1);
+
+        // then
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("조회 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
+    public void testIfFamilyExistedButDeletedWhenGetThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.getFamily(user1);
+        });
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 자녀일 경우, 에러 처리 하는지 확인")
+    public void testIfAKidTryToGetKidListThenThrowForbiddenException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(null));
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(ForbiddenException.class, () -> {
+            familyController.getFamilyKidList(user1);
+        });
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 결과 있을 때, 아이 리스트 정보 가나다순으로 반환하는지 확인")
+    public void testIfFamilyExistThenReturnKidListResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("성우")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("민준")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("어진")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        User user4 = User.builder()
+            .id(4L)
+            .username("규진")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+        Kid kid2 = Kid.builder().level(1L).user(user2).build();
+        Kid kid3 = Kid.builder().level(2L).user(user3).build();
+        Kid kid4 = Kid.builder().level(3L).user(user4).build();
+        user2.setKid(kid2);
+        user3.setKid(kid3);
+        user4.setKid(kid4);
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family).build();
+        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser4);
+        familyUserList.add(familyUser2);
+        familyUserList.add(familyUser3);
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<List<KidListDTO>> result = familyController.getFamilyKidList(user1);
+
+        // then
+        List<KidListDTO> kidListDTOList = familyUserList.stream().map(FamilyUser::getUser)
+            .filter(User::getIsKid).map(KidListDTO::new).collect(
+                Collectors.toList());
+        Assertions.assertEquals(CommonResponse.onSuccess(kidListDTOList), result);
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 결과 없을 때, 빈 리스트 반환하는지 확인")
+    public void testIfFamilyExistButNotKidThenReturnEmptyList() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        Family family = Family.builder().id(1L).code("code").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<FamilyUser>();
+        familyUserList.add(familyUser1);
+        familyUserList.add(familyUser2);
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1)).thenReturn(
+            Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<List<KidListDTO>> result = familyController.getFamilyKidList(user1);
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new ArrayList()), result);
+    }
+
+    @Test
+    @DisplayName("아이 조회 시 가족 없을 때, 에러 처리 하는지 확인")
+    public void testIfFamilyNotExistThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L)).thenReturn(
+            Optional.ofNullable(null));
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.getFamilyKidList(user1);
+        });
+    }
+
+    @Test
+    @DisplayName("가족 참여 시 기존 가족 있을 때, 삭제 후 새 가족 참여하는지 확인")
+    public void testIfLeaveFamilyAndJoinNewFamilyThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .serviceOptIn(false)
+            .noticeOptIn(false)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .serviceOptIn(false)
+            .build();
+
+        Family family1 = Family.builder().id(1L).code("code").build();
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family1).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser2);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(family2));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.postFamilyUser(user1, familyRequest);
+        String code = result.getData().getCode();
+        family1.setCode(code);
+
+        // then
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+        familyUser1.setFamily(family2);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
+
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("가족 참여 시 기존 가족 없을 때, 새 가족 참여하는지 확인")
+    public void testIfJoinNewFamilyThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(family2));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        familyUser1.setFamily(family2);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.postFamilyUser(user1, familyRequest);
+        String code = result.getData().getCode();
+        family2.setCode(code);
+
+        // then
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        familyUser1.setFamily(family2);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("가족 참여 시 해당 가족 구성원일 때, 에러 처리 하는지 확인")
+    public void testIfUserIsAlreadyInFamilyThenThrowForbiddenException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser1);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(family2));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(ForbiddenException.class, () -> {
+            familyController.postFamilyUser(user1, familyRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("엄마로 가족 참여 시 엄마가 이미 존재할 때, 에러 처리 하는지 확인")
+    public void testIfUserIsMomAndMomAlreadyInFamilyThenThrowForbiddenException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("user3")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(false)
+            .build();
+        User user4 = User.builder()
+            .id(4L)
+            .username("user4")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(false)
+            .build();
+        User user5 = User.builder()
+            .id(5L)
+            .username("user5")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+
+        Family family1 = Family.builder().id(1L).code("code").build();
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family1).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family2).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
+        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser2);
+        familyUserList.add(familyUser3);
+        familyUserList.add(familyUser4);
+        familyUserList.add(familyUser5);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
+        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(family2));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(ForbiddenException.class, () -> {
+            familyController.postFamilyUser(user1, familyRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("엄마로 가족 참여 시 엄마 존재하지 않을 때, 결과 반환 하는지 확인")
+    public void testIfUserIsMomAndMomNotInFamilyThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .serviceOptIn(false)
+            .noticeOptIn(false)
+            .expoToken("ExponentPushToken[dfdf]")
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("user3")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(false)
+            .serviceOptIn(true)
+            .noticeOptIn(true)
+            .expoToken("ExponentPushToken[dfdf]")
+            .build();
+        User user4 = User.builder()
+            .id(4L)
+            .username("user4")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(false)
+            .serviceOptIn(false)
+            .noticeOptIn(true)
+            .expoToken("ExponentPushToken[dfdf]")
+            .build();
+        User user5 = User.builder()
+            .id(5L)
+            .username("user5")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .serviceOptIn(true)
+            .noticeOptIn(false)
+            .expoToken("ExponentPushToken[dfdf]")
+            .build();
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
+        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser3);
+        familyUserList.add(familyUser4);
+        familyUserList.add(familyUser5);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(family2));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        familyUser1.setFamily(family2);
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.postFamilyUser(user1, familyRequest);
+        String code = result.getData().getCode();
+        family2.setCode(code);
+
+        // then
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        familyUser1.setFamily(family2);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("아빠로 가족 참여 시 아빠가 이미 존재할 때, 에러 처리 하는지 확인")
+    public void testIfUserIsDadAndDadAlreadyInFamilyThenThrowForbiddenException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(false)
+            .serviceOptIn(false)
+            .noticeOptIn(true)
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(false)
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("user3")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user4 = User.builder()
+            .id(4L)
+            .username("user4")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(false)
+            .build();
+        User user5 = User.builder()
+            .id(5L)
+            .username("user5")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+
+        Family family1 = Family.builder().id(1L).code("code").build();
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family1).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family2).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
+        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser2);
+        familyUserList.add(familyUser3);
+        familyUserList.add(familyUser4);
+        familyUserList.add(familyUser5);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family1));
+        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(family2));
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(family2));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(ForbiddenException.class, () -> {
+            familyController.postFamilyUser(user1, familyRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("아빠로 가족 참여 시 아빠 존재하지 않을 때, 결과 반환 하는지 확인")
+    public void testIfUserIsDadAndDadNotInFamilyThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(false)
+            .serviceOptIn(true)
+            .noticeOptIn(true)
+            .expoToken("ExponentPushToken[dfdf]")
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("user3")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .serviceOptIn(false)
+            .noticeOptIn(true)
+            .expoToken("ExponentPushToken[dfdf]")
+            .build();
+        User user4 = User.builder()
+            .id(4L)
+            .username("user4")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(false)
+            .serviceOptIn(true)
+            .noticeOptIn(false)
+            .expoToken("ExponentPushToken[dfdf]")
+            .build();
+        User user5 = User.builder()
+            .id(5L)
+            .username("user5")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .serviceOptIn(false)
+            .noticeOptIn(false)
+            .expoToken("ExponentPushToken[dfdf]")
+            .build();
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
+        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser3);
+        familyUserList.add(familyUser4);
+        familyUserList.add(familyUser5);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(family2));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        familyUser1.setFamily(family2);
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.postFamilyUser(user1, familyRequest);
+        String code = result.getData().getCode();
+        family2.setCode(code);
+
+        // then
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        familyUser1.setFamily(family2);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).save(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(family2)
+            .familyUserList(
+                familyUserList
+                    .stream()
+                    .map(FamilyUserDTO::new)
+                    .collect(Collectors.toList())
+            ).build();
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
+    }
+
+    @Test
+    @DisplayName("가족 참여 시 참여하려는 가족이 없을 때, 에러 처리 하는지 확인")
+    public void testIfFamilyToJoinNotExistThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(false)
+            .build();
+
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(2L)).thenReturn(Optional.ofNullable(null));
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(null));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.postFamilyUser(user1, familyRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("예외) 부모로 가족 참여 시 성별 선택 안되었을 때, 에러 처리 하는지 확인")
+    public void testIfUserIsParentButSexUnknownThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(null)
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("user3")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+        User user4 = User.builder()
+            .id(4L)
+            .username("user4")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(false)
+            .build();
+        User user5 = User.builder()
+            .id(5L)
+            .username("user5")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(true)
+            .build();
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+        FamilyUser familyUser4 = FamilyUser.builder().user(user4).family(family2).build();
+        FamilyUser familyUser5 = FamilyUser.builder().user(user5).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser3);
+        familyUserList.add(familyUser4);
+        familyUserList.add(familyUser5);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findByCode("test"))
+            .thenReturn(Optional.ofNullable(family2));
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        familyUser1.setFamily(family2);
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.postFamilyUser(user1, familyRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("부모 가족 나가기 성공 시, 결과 반환 하는지 확인")
+    public void testIfParentFamilyUserDeleteSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(null)
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("user3")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+
+        user1.setParent(parent);
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser3);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = Mockito.mock(
+            ChallengeUserServiceImpl.class);
+        KidServiceImpl kidService = Mockito.mock(KidServiceImpl.class);
+        ParentServiceImpl parentService = Mockito.mock(ParentServiceImpl.class);
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
+
+        // then
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+    }
+
+    @Test
+    @DisplayName("자녀 가족 나가기 성공 시, 결과 반환 하는지 확인")
+    public void testIfKidFamilyUserDeleteSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(null)
+            .build();
+        User user3 = User.builder()
+            .id(3L)
+            .username("user3")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(true)
+            .build();
+
+        Kid kid = Kid.builder()
+            .id(1L)
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user1)
+            .build();
+
+        user1.setKid(kid);
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        FamilyUser familyUser3 = FamilyUser.builder().user(user3).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser3);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = Mockito.mock(
+            ChallengeUserServiceImpl.class);
+        KidServiceImpl kidService = Mockito.mock(KidServiceImpl.class);
+        ParentServiceImpl parentService = Mockito.mock(ParentServiceImpl.class);
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
+
+        // then
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+    }
+
+    @Test
+    @DisplayName("유저 가족 나가기 성공 후 가족 없어 삭제 성공 시, 결과 반환 하는지 확인")
+    public void testIfFamilyUserDeleteSucceedAndFamilyDeleteSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(null)
+            .build();
+
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+
+        user1.setParent(parent);
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family2, user1))
+            .thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = Mockito.mock(
+            ChallengeUserServiceImpl.class);
+        KidServiceImpl kidService = Mockito.mock(KidServiceImpl.class);
+        ParentServiceImpl parentService = Mockito.mock(ParentServiceImpl.class);
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        CommonResponse<FamilyDTO> result = familyController.deleteFamilyUser(user1, familyRequest);
+
+        // then
+        ArgumentCaptor<FamilyUser> fuCaptor = ArgumentCaptor.forClass(FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1)).delete(fuCaptor.capture());
+        Assertions.assertEquals(familyUser1, fuCaptor.getValue());
+
+        ArgumentCaptor<Family> fCaptor = ArgumentCaptor.forClass(Family.class);
+        Mockito.verify(mockFamilyRepository, Mockito.times(1)).delete(fCaptor.capture());
+        Assertions.assertEquals(family2, fCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+    }
+
+    @Test
+    @DisplayName("유저가 가입된 가족이 없는 경우, 에러 처리 하는지 확인")
+    public void testIfFamilyUserDeleteFailBecauseFamilyUserNotExistThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(null)
+            .build();
+
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+
+        user1.setParent(parent);
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        FamilyRequest familyRequest = new FamilyRequest("test");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.deleteFamilyUser(user1, familyRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("자녀가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
+    public void testIfKidFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(true)
+            .isFemale(null)
+            .build();
+
+        Kid kid = Kid.builder()
+            .id(1L)
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user1)
+            .build();
+
+        user1.setKid(kid);
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        FamilyRequest familyRequest = new FamilyRequest("code");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.deleteFamilyUser(user1, familyRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("부모가 가입 된 가족과 다른 가족을 탈퇴하고자 할 때, 에러 처리 하는지 확인")
+    public void testIfParentFamilyUserDeleteFailDueToDifferentRequestCodeThenThrowBadRequestException() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .isKid(false)
+            .isFemale(null)
+            .build();
+
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+
+        user1.setParent(parent);
+
+        Family family2 = Family.builder().id(2L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family2).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        FamilyRequest familyRequest = new FamilyRequest("code");
+
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamily(family2)).thenReturn(familyUserList);
+        NotificationMapper mockNotificationMapper = Mockito.mock(
+            NotificationMapper.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        NotificationRepository notificationRepository = Mockito.mock(NotificationRepository.class);
+
+        // when
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ExpoNotificationServiceImpl notificationService = new ExpoNotificationServiceImpl(
+            notificationRepository);
+        FamilyMapper familyMapper = new FamilyMapper(
+            familyService,
+            familyUserService,
+            notificationService,
+            challengeService,
+            challengeUserService,
+            kidService,
+            parentService
+        );
+        FamilyController familyController = new FamilyController(familyMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            familyController.deleteFamilyUser(user1, familyRequest);
+        });
+    }
+
+}

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -1,1921 +1,1990 @@
-//package com.ceos.bankids.unit.controller;
-//
-//import com.ceos.bankids.config.CommonResponse;
-//import ExpoRequest;
-//import FamilyRequest;
-//import UserTypeRequest;
-//import WithdrawalRequest;
-//import com.ceos.bankids.domain.Family;
-//import com.ceos.bankids.domain.FamilyUser;
-//import com.ceos.bankids.domain.Kid;
-//import com.ceos.bankids.domain.KidBackup;
-//import com.ceos.bankids.domain.Parent;
-//import com.ceos.bankids.domain.ParentBackup;
-//import com.ceos.bankids.domain.User;
-//import com.ceos.bankids.dto.KidDTO;
-//import com.ceos.bankids.dto.LoginDTO;
-//import com.ceos.bankids.dto.MyPageDTO;
-//import com.ceos.bankids.dto.OptInDTO;
-//import com.ceos.bankids.dto.ParentDTO;
-//import com.ceos.bankids.dto.TokenDTO;
-//import com.ceos.bankids.dto.UserDTO;
-//import com.ceos.bankids.exception.BadRequestException;
-//import com.ceos.bankids.repository.FamilyRepository;
-//import com.ceos.bankids.repository.FamilyUserRepository;
-//import com.ceos.bankids.repository.KidBackupRepository;
-//import com.ceos.bankids.repository.KidRepository;
-//import com.ceos.bankids.repository.ParentBackupRepository;
-//import com.ceos.bankids.repository.ParentRepository;
-//import com.ceos.bankids.repository.UserRepository;
-//import com.ceos.bankids.service.ChallengeServiceImpl;
-//import com.ceos.bankids.service.ExpoNotificationServiceImpl;
-//import com.ceos.bankids.service.FamilyServiceImpl;
-//import com.ceos.bankids.service.FamilyUserServiceImpl;
-//import com.ceos.bankids.service.JwtTokenServiceImpl;
-//import com.ceos.bankids.service.KidBackupServiceImpl;
-//import com.ceos.bankids.service.KidServiceImpl;
-//import com.ceos.bankids.service.ParentBackupServiceImpl;
-//import com.ceos.bankids.service.ParentServiceImpl;
-//import com.ceos.bankids.service.SlackServiceImpl;
-//import com.ceos.bankids.service.UserServiceImpl;
-//import java.util.ArrayList;
-//import java.util.List;
-//import java.util.Optional;
-//import javax.servlet.http.HttpServletResponse;
-//import org.junit.jupiter.api.Assertions;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.ArgumentCaptor;
-//import org.mockito.Mockito;
-//
-//public class UserControllerTest {
-//
-//    @Test
-//    @DisplayName("유저 타입 패치 성공시, 결과 반환 하는지 확인")
-//    public void testIfUserTypePatchSucceedReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository);
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl,
-//            challengeUserServiceImpl
-//        );
-//        CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
-//
-//        // then
-//        user.setBirthday("19990521");
-//        user.setIsFemale(false);
-//        user.setIsKid(true);
-//        UserDTO userDTO = new UserDTO(user);
-//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 정보 이미 있어 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWhenAlreadyPatchedThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("body 없어서 패치 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWithoutArgumentsThrowNullPointerException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        // then
-//        Assertions.assertThrows(NullPointerException.class, () -> {
-//            userController.patchUserType(user, null);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("100세 초과 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWithTooEarlyBirthdayThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("18880818", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("0세 미만 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWithTooLateBirthdayThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("23450818", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("자녀 지정시, 자녀 row 생성 확인")
-//    public void testIfKidInsertSucceedWhenUserTypePatchSucceed() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        Kid kid = Kid.builder()
-//            .savings(0L)
-//            .user(user)
-//            .level(1L)
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        Mockito.when(mockKidRepository.save(kid)).thenReturn(kid);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository);
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//        CommonResponse result = userController.patchUserType(user, userTypeRequest);
-//
-//        // then
-//        user.setBirthday("19990521");
-//        user.setIsFemale(false);
-//        user.setIsKid(true);
-//        UserDTO userDTO = new UserDTO(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        ArgumentCaptor<Kid> kCaptor = ArgumentCaptor.forClass(Kid.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Mockito.verify(mockKidRepository, Mockito.times(1)).save(kCaptor.capture());
-//
-//        Assertions.assertEquals(user, uCaptor.getValue());
-//        Assertions.assertEquals(kid, kCaptor.getValue());
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("부모 지정시, 부모 row 생성 확인")
-//    public void testIfParentInsertSucceedWhenUserTypePatchSucceed() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .refreshToken("token")
-//            .build();
-//        Parent parent = Parent.builder()
-//            .user(user)
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", true, false);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        Mockito.when(mockParentRepository.save(parent)).thenReturn(parent);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//        CommonResponse result = userController.patchUserType(user, userTypeRequest);
-//
-//        // then
-//        user.setBirthday("19990521");
-//        user.setIsFemale(true);
-//        user.setIsKid(false);
-//        UserDTO userDTO = new UserDTO(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        ArgumentCaptor<Parent> pCaptor = ArgumentCaptor.forClass(Parent.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Mockito.verify(mockParentRepository, Mockito.times(1)).save(pCaptor.capture());
-//
-//        Assertions.assertEquals(user, uCaptor.getValue());
-//        Assertions.assertEquals(parent, pCaptor.getValue());
-//
-//        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("이미 타입을 선택한 유저 접근시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWhenAlreadyRegisteredThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("부모 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-//    public void testIfParentTokenRefreshSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        TokenDTO tokenDTO = new TokenDTO(user);
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn(1L);
-//
-//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//        CommonResponse result = userController.refreshUserToken(user);
-//
-//        // then
-//        LoginDTO loginDTO = new LoginDTO(false, "aT", user.getProvider());
-//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("자녀 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-//    public void testIfKidTokenRefreshSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//        Kid kid = Kid.builder()
-//            .level(1L)
-//            .user(user)
-//            .build();
-//        user.setKid(kid);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        TokenDTO tokenDTO = new TokenDTO(user);
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn(1L);
-//
-//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.refreshUserToken(user);
-//
-//        // then
-//        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L, user.getProvider());
-//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("타입 미선택 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
-//    public void testIfUserTokenRefreshSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(null)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(null)
-//            .refreshToken("token")
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        TokenDTO tokenDTO = new TokenDTO(user);
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
-//        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
-//        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn(1L);
-//
-//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.refreshUserToken(user);
-//
-//        // then
-//        LoginDTO loginDTO = new LoginDTO(null, "aT", user.getProvider());
-//        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
-//    }
-//
-//
-//    @Test
-//    @DisplayName("부모 유저 정보 조회 성공 시, 부모 결과 반환하는지 확인")
-//    public void testIfGetParentInfoSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//        Parent parent = Parent.builder()
-//            .acceptedRequest(0L)
-//            .totalRequest(0L)
-//            .user(user)
-//            .build();
-//        user.setParent(parent);
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.getUserInfo(user);
-//
-//        // then
-//        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new ParentDTO(parent));
-//        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("자녀 유저 정보 조회 성공 시, 자녀 결과 반환하는지 확인")
-//    public void testIfGetKidInfoSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//        Kid kid = Kid.builder()
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(1L)
-//            .user(user)
-//            .build();
-//        user.setKid(kid);
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.getUserInfo(user);
-//
-//        // then
-//        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new KidDTO(kid));
-//        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 타입 선택 없이 유저 정보 조회 시, 에러 처리하는지 확인")
-//    public void testIfGetUserInfoFailWithoutUserTypeThenThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(null)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(null)
-//            .refreshToken("token")
-//            .build();
-//        Kid kid = Kid.builder()
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(1L)
-//            .user(user)
-//            .build();
-//        user.setKid(kid);
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.getUserInfo(user);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("유저 로그아웃 성공 시, null 반환하는지 확인")
-//    public void testIfUserLogoutSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.patchUserLogout(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        user.setRefreshToken("");
-//        user.setExpoToken("");
-//        Assertions.assertEquals(user.getRefreshToken(), uCaptor.getValue().getRefreshToken());
-//        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
-//    }
-//
-//    @Test
-//    @DisplayName("가족 없는 부모 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
-//    public void testIfParentUserWithoutFamilyDeleteAccountSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .birthday("12345678")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//        user1.setParent(parent);
-//        ParentBackup parentBackup = ParentBackup.builder()
-//            .birthYear(user1.getBirthday().substring(0, 4))
-//            .isKid(user1.getIsKid())
-//            .acceptedRequest(user1.getParent().getAcceptedRequest())
-//            .totalRequest(user1.getParent().getTotalRequest())
-//            .build();
-//        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
-//
-//        // mock
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//
-//        ParentBackupRepository mockParentBackupRepository = Mockito.mock(
-//            ParentBackupRepository.class);
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        NotificationController mockNotificationController = Mockito.mock(
-//            NotificationController.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository);
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = new ParentBackupServiceImpl(
-//            mockParentBackupRepository);
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
-//        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
-//        Mockito.doNothing().when(slackService)
-//            .sendWithdrawalMessage("ParentBackup ", parentBackup.getId(),
-//                withdrawalRequest.getMessage());
-//        ExpoNotificationServiceImpl notificationService = Mockito.mock(
-//            ExpoNotificationServiceImpl.class);
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
-//
-//        ArgumentCaptor<ParentBackup> parentBackupCaptor = ArgumentCaptor.forClass(
-//            ParentBackup.class);
-//        Mockito.verify(mockParentBackupRepository, Mockito.times(1))
-//            .save(parentBackupCaptor.capture());
-//        Assertions.assertEquals(parentBackup, parentBackupCaptor.getValue());
-//
-//        ArgumentCaptor<Parent> parentCaptor = ArgumentCaptor.forClass(
-//            Parent.class);
-//        Mockito.verify(mockParentRepository, Mockito.times(1))
-//            .delete(parentCaptor.capture());
-//        Assertions.assertEquals(user1.getParent(), parentCaptor.getValue());
-//
-//        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
-//            User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1))
-//            .delete(userCaptor.capture());
-//        Assertions.assertEquals(user1, userCaptor.getValue());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
-//    }
-//
-//    @Test
-//    @DisplayName("가족 없는 자녀 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
-//    public void testIfKidUserWithoutFamilyDeleteAccountSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .birthday("12345678")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//
-//        Kid kid = Kid.builder()
-//            .id(1L)
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(0L)
-//            .user(user1)
-//            .build();
-//        user1.setKid(kid);
-//        KidBackup kidBackup = KidBackup.builder()
-//            .birthYear(user1.getBirthday().substring(0, 4))
-//            .isKid(user1.getIsKid())
-//            .savings(user1.getKid().getSavings())
-//            .achievedChallenge(user1.getKid().getAchievedChallenge())
-//            .totalChallenge(user1.getKid().getTotalChallenge())
-//            .level(user1.getKid().getLevel())
-//            .build();
-//        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
-//
-//        // mock
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
-//            .thenReturn(Optional.ofNullable(null));
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//
-//        KidBackupRepository mockKidBackupRepository = Mockito.mock(
-//            KidBackupRepository.class);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        NotificationController mockNotificationController = Mockito.mock(
-//            NotificationController.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository);
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository);
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
-//        Mockito.doNothing().when(slackService)
-//            .sendWithdrawalMessage("KidBackup ", kidBackup.getId(),
-//                withdrawalRequest.getMessage());
-//        ExpoNotificationServiceImpl notificationService = Mockito.mock(
-//            ExpoNotificationServiceImpl.class);
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
-//
-//        ArgumentCaptor<KidBackup> kidBackupCaptor = ArgumentCaptor.forClass(
-//            KidBackup.class);
-//        Mockito.verify(mockKidBackupRepository, Mockito.times(1))
-//            .save(kidBackupCaptor.capture());
-//        Assertions.assertEquals(kidBackup, kidBackupCaptor.getValue());
-//
-//        ArgumentCaptor<Kid> kidCaptor = ArgumentCaptor.forClass(
-//            Kid.class);
-//        Mockito.verify(mockKidRepository, Mockito.times(1))
-//            .delete(kidCaptor.capture());
-//        Assertions.assertEquals(user1.getKid(), kidCaptor.getValue());
-//
-//        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
-//            User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1))
-//            .delete(userCaptor.capture());
-//        Assertions.assertEquals(user1, userCaptor.getValue());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
-//    }
-//
-//    @Test
-//    @DisplayName("가족 있는 부모 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
-//    public void testIfParentUserWithFamilyDeleteAccountSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .birthday("12345678")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .birthday("12345678")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//
-//        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
-//            .build();
-//        user1.setParent(parent);
-//        ParentBackup parentBackup = ParentBackup.builder()
-//            .birthYear(user1.getBirthday().substring(0, 4))
-//            .isKid(user1.getIsKid())
-//            .acceptedRequest(user1.getParent().getAcceptedRequest())
-//            .totalRequest(user1.getParent().getTotalRequest())
-//            .build();
-//
-//        Family family = Family.builder().id(1L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser2);
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
-//
-//        // mock
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
-//            .thenReturn(familyUserList);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
-//
-//        ParentBackupRepository mockParentBackupRepository = Mockito.mock(
-//            ParentBackupRepository.class);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        NotificationController mockNotificationController = Mockito.mock(
-//            NotificationController.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository);
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = new ParentBackupServiceImpl(
-//            mockParentBackupRepository);
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
-//        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
-//        Mockito.doNothing().when(slackService)
-//            .sendWithdrawalMessage("ParentBackup ", parentBackup.getId(),
-//                withdrawalRequest.getMessage());
-//        ExpoNotificationServiceImpl notificationService = Mockito.mock(
-//            ExpoNotificationServiceImpl.class);
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
-//
-//        ArgumentCaptor<FamilyUser> familyUserCaptor = ArgumentCaptor.forClass(
-//            FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1))
-//            .delete(familyUserCaptor.capture());
-//        Assertions.assertEquals(familyUser1, familyUserCaptor.getValue());
-//
-//        ArgumentCaptor<ParentBackup> parentBackupCaptor = ArgumentCaptor.forClass(
-//            ParentBackup.class);
-//        Mockito.verify(mockParentBackupRepository, Mockito.times(1))
-//            .save(parentBackupCaptor.capture());
-//        Assertions.assertEquals(parentBackup, parentBackupCaptor.getValue());
-//
-//        ArgumentCaptor<Parent> parentCaptor = ArgumentCaptor.forClass(
-//            Parent.class);
-//        Mockito.verify(mockParentRepository, Mockito.times(1))
-//            .delete(parentCaptor.capture());
-//        Assertions.assertEquals(user1.getParent(), parentCaptor.getValue());
-//
-//        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
-//            User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1))
-//            .delete(userCaptor.capture());
-//        Assertions.assertEquals(user1, userCaptor.getValue());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
-//    }
-//
-//    @Test
-//    @DisplayName("가족 있는 자녀 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
-//    public void testIfKidUserWithFamilyDeleteAccountSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .birthday("12345678")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//        User user2 = User.builder()
-//            .id(2L)
-//            .username("user2")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .birthday("12345678")
-//            .provider("kakao")
-//            .isKid(false)
-//            .refreshToken("token")
-//            .build();
-//
-//        Kid kid = Kid.builder()
-//            .id(1L)
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(0L)
-//            .user(user1)
-//            .build();
-//        user1.setKid(kid);
-//        KidBackup kidBackup = KidBackup.builder()
-//            .birthYear(user1.getBirthday().substring(0, 4))
-//            .isKid(user1.getIsKid())
-//            .savings(user1.getKid().getSavings())
-//            .achievedChallenge(user1.getKid().getAchievedChallenge())
-//            .totalChallenge(user1.getKid().getTotalChallenge())
-//            .level(user1.getKid().getLevel())
-//            .build();
-//
-//        Family family = Family.builder().id(1L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//        familyUserList.add(familyUser2);
-//
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
-//
-//        // mock
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
-//            .thenReturn(familyUserList);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
-//
-//        KidBackupRepository mockKidBackupRepository = Mockito.mock(
-//            KidBackupRepository.class);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        NotificationController mockNotificationController = Mockito.mock(
-//            NotificationController.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository);
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository);
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
-//        Mockito.doNothing().when(slackService)
-//            .sendWithdrawalMessage("KidBackup ", kidBackup.getId(),
-//                withdrawalRequest.getMessage());
-//        ExpoNotificationServiceImpl notificationService = Mockito.mock(
-//            ExpoNotificationServiceImpl.class);
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
-//
-//        ArgumentCaptor<FamilyUser> familyUserCaptor = ArgumentCaptor.forClass(
-//            FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1))
-//            .delete(familyUserCaptor.capture());
-//        Assertions.assertEquals(familyUser1, familyUserCaptor.getValue());
-//
-//        ArgumentCaptor<KidBackup> kidBackupCaptor = ArgumentCaptor.forClass(
-//            KidBackup.class);
-//        Mockito.verify(mockKidBackupRepository, Mockito.times(1))
-//            .save(kidBackupCaptor.capture());
-//        Assertions.assertEquals(kidBackup, kidBackupCaptor.getValue());
-//
-//        ArgumentCaptor<Kid> kidCaptor = ArgumentCaptor.forClass(
-//            Kid.class);
-//        Mockito.verify(mockKidRepository, Mockito.times(1))
-//            .delete(kidCaptor.capture());
-//        Assertions.assertEquals(user1.getKid(), kidCaptor.getValue());
-//
-//        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
-//            User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1))
-//            .delete(userCaptor.capture());
-//        Assertions.assertEquals(user1, userCaptor.getValue());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
-//    }
-//
-//    @Test
-//    @DisplayName("가족에 혼자인 유저 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
-//    public void testIfKidUserWithFamilyAloneDeleteAccountSucceedThenReturnResult() {
-//        // given
-//        User user1 = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .birthday("12345678")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .build();
-//
-//        Kid kid = Kid.builder()
-//            .id(1L)
-//            .savings(0L)
-//            .achievedChallenge(0L)
-//            .totalChallenge(0L)
-//            .level(0L)
-//            .user(user1)
-//            .build();
-//        user1.setKid(kid);
-//        KidBackup kidBackup = KidBackup.builder()
-//            .birthYear(user1.getBirthday().substring(0, 4))
-//            .isKid(user1.getIsKid())
-//            .savings(user1.getKid().getSavings())
-//            .achievedChallenge(user1.getKid().getAchievedChallenge())
-//            .totalChallenge(user1.getKid().getTotalChallenge())
-//            .level(user1.getKid().getLevel())
-//            .build();
-//
-//        Family family = Family.builder().id(1L).code("test").build();
-//        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
-//        List<FamilyUser> familyUserList = new ArrayList<>();
-//
-//        FamilyRequest familyRequest = new FamilyRequest("test");
-//        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
-//
-//        // mock
-//        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
-//        Mockito.when(mockFamilyUserRepository.findByUser(user1))
-//            .thenReturn(Optional.ofNullable(familyUser1));
-//        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
-//            .thenReturn(familyUserList);
-//        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
-//        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
-//
-//        KidBackupRepository mockKidBackupRepository = Mockito.mock(
-//            KidBackupRepository.class);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//        NotificationController mockNotificationController = Mockito.mock(
-//            NotificationController.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
-//        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
-//            mockFamilyUserRepository);
-//        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
-//        KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository);
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
-//        Mockito.doNothing().when(slackService)
-//            .sendWithdrawalMessage("KidBackup ", kidBackup.getId(),
-//                withdrawalRequest.getMessage());
-//        ExpoNotificationServiceImpl notificationService = Mockito.mock(
-//            ExpoNotificationServiceImpl.class);
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
-//
-//        ArgumentCaptor<FamilyUser> familyUserCaptor = ArgumentCaptor.forClass(
-//            FamilyUser.class);
-//        Mockito.verify(mockFamilyUserRepository, Mockito.times(1))
-//            .delete(familyUserCaptor.capture());
-//        Assertions.assertEquals(familyUser1, familyUserCaptor.getValue());
-//
-//        ArgumentCaptor<Family> familyCaptor = ArgumentCaptor.forClass(
-//            Family.class);
-//        Mockito.verify(mockFamilyRepository, Mockito.times(1))
-//            .delete(familyCaptor.capture());
-//        Assertions.assertEquals(family, familyCaptor.getValue());
-//
-//        ArgumentCaptor<KidBackup> kidBackupCaptor = ArgumentCaptor.forClass(
-//            KidBackup.class);
-//        Mockito.verify(mockKidBackupRepository, Mockito.times(1))
-//            .save(kidBackupCaptor.capture());
-//        Assertions.assertEquals(kidBackup, kidBackupCaptor.getValue());
-//
-//        ArgumentCaptor<Kid> kidCaptor = ArgumentCaptor.forClass(
-//            Kid.class);
-//        Mockito.verify(mockKidRepository, Mockito.times(1))
-//            .delete(kidCaptor.capture());
-//        Assertions.assertEquals(user1.getKid(), kidCaptor.getValue());
-//
-//        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
-//            User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1))
-//            .delete(userCaptor.capture());
-//        Assertions.assertEquals(user1, userCaptor.getValue());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 엑스포 토큰 패치 성공 시, null 반환하는지 확인")
-//    public void testIfUserExpoTokenPatchSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .expoToken("ExponentPushToken[dd]")
-//            .build();
-//        ExpoRequest expoRequest = new ExpoRequest("ExponentPushToken[dd]");
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse result = userController.patchExpoToken(user, expoRequest, response);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 공지 및 이벤트 알림 동의 시, 결과 반환하는지 확인")
-//    public void testIfUserPatchNoticeOptInSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .expoToken("ExponentPushToken[dd]")
-//            .noticeOptIn(false)
-//            .serviceOptIn(false)
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse<OptInDTO> result = userController.patchNoticeOptIn(user);
-//
-//        user.setNoticeOptIn(true);
-//        OptInDTO optInDTO = new OptInDTO(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Assertions.assertEquals(user.getNoticeOptIn(), uCaptor.getValue().getNoticeOptIn());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(optInDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 가족 활동 알림 동의 시, 결과 반환하는지 확인")
-//    public void testIfUserPatchServiceOptInSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .expoToken("ExponentPushToken[dd]")
-//            .noticeOptIn(false)
-//            .serviceOptIn(false)
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse<OptInDTO> result = userController.patchServiceOptIn(user);
-//
-//        user.setServiceOptIn(true);
-//        OptInDTO optInDTO = new OptInDTO(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Assertions.assertEquals(user.getServiceOptIn(), uCaptor.getValue().getServiceOptIn());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(optInDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 공지 및 이벤트 알림 비동의 시, 결과 반환하는지 확인")
-//    public void testIfUserPatchNoticeOptOutSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .expoToken("ExponentPushToken[dd]")
-//            .noticeOptIn(true)
-//            .serviceOptIn(false)
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse<OptInDTO> result = userController.patchNoticeOptIn(user);
-//
-//        user.setNoticeOptIn(false);
-//        OptInDTO optInDTO = new OptInDTO(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Assertions.assertEquals(user.getNoticeOptIn(), uCaptor.getValue().getNoticeOptIn());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(optInDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 가족 활동 알림 비동의 시, 결과 반환하는지 확인")
-//    public void testIfUserPatchServiceOptOutSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .expoToken("ExponentPushToken[dd]")
-//            .noticeOptIn(false)
-//            .serviceOptIn(true)
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse<OptInDTO> result = userController.patchServiceOptIn(user);
-//
-//        user.setServiceOptIn(false);
-//        OptInDTO optInDTO = new OptInDTO(user);
-//
-//        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
-//        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
-//        Assertions.assertEquals(user.getServiceOptIn(), uCaptor.getValue().getServiceOptIn());
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(optInDTO), result);
-//    }
-//
-//    @Test
-//    @DisplayName("유저 생년월일이 유효하지 않아 실패 시, 에러 처리 되는지 확인")
-//    public void testIfUserTypePatchFailWithInvalidBirthdayThrowBadRequestException() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(null)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(null)
-//            .refreshToken("token")
-//            .build();
-//        UserTypeRequest userTypeRequest = new UserTypeRequest("23450231", false, true);
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        Mockito.when(mockUserRepository.findById(1L))
-//            .thenReturn(Optional.ofNullable(user));
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        // then
-//        Assertions.assertThrows(BadRequestException.class, () -> {
-//            userController.patchUserType(user, userTypeRequest);
-//        });
-//    }
-//
-//    @Test
-//    @DisplayName("유저 푸시 알림 동의 여부 조회 시, 결과 반환하는지 확인")
-//    public void testIfGetUserOptInSucceedThenReturnResult() {
-//        // given
-//        User user = User.builder()
-//            .id(1L)
-//            .username("user1")
-//            .isFemale(true)
-//            .authenticationCode("code")
-//            .provider("kakao")
-//            .isKid(true)
-//            .refreshToken("token")
-//            .expoToken("ExponentPushToken[dd]")
-//            .noticeOptIn(false)
-//            .serviceOptIn(true)
-//            .build();
-//
-//        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
-//        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
-//        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
-//        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
-//
-//        // when
-//        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
-//        FamilyServiceImpl familyService = null;
-//        FamilyUserServiceImpl familyUserService = null;
-//        ChallengeServiceImpl challengeService = null;
-//        KidBackupServiceImpl kidBackupService = null;
-//        ParentBackupServiceImpl parentBackupService = null;
-//        KidServiceImpl kidService = null;
-//        ParentServiceImpl parentService = null;
-//        SlackServiceImpl slackService = null;
-//        ExpoNotificationServiceImpl notificationService = null;
-//
-//        UserController userController = new UserController(
-//            userService,
-//            familyService,
-//            familyUserService,
-//            challengeService,
-//            kidBackupService,
-//            parentBackupService,
-//            kidService,
-//            parentService,
-//            slackService,
-//            notificationService,
-//            jwtTokenServiceImpl
-//        );
-//
-//        CommonResponse<OptInDTO> result = userController.getOptIn(user);
-//
-//        // then
-//        Assertions.assertEquals(CommonResponse.onSuccess(new OptInDTO(user)), result);
-//    }
-//}
+package com.ceos.bankids.unit.controller;
+
+import com.ceos.bankids.config.CommonResponse;
+import com.ceos.bankids.controller.NotificationController;
+import com.ceos.bankids.controller.UserController;
+import com.ceos.bankids.controller.request.ExpoRequest;
+import com.ceos.bankids.controller.request.FamilyRequest;
+import com.ceos.bankids.controller.request.UserTypeRequest;
+import com.ceos.bankids.controller.request.WithdrawalRequest;
+import com.ceos.bankids.domain.Family;
+import com.ceos.bankids.domain.FamilyUser;
+import com.ceos.bankids.domain.Kid;
+import com.ceos.bankids.domain.KidBackup;
+import com.ceos.bankids.domain.Parent;
+import com.ceos.bankids.domain.ParentBackup;
+import com.ceos.bankids.domain.User;
+import com.ceos.bankids.dto.KidDTO;
+import com.ceos.bankids.dto.LoginDTO;
+import com.ceos.bankids.dto.MyPageDTO;
+import com.ceos.bankids.dto.OptInDTO;
+import com.ceos.bankids.dto.ParentDTO;
+import com.ceos.bankids.dto.TokenDTO;
+import com.ceos.bankids.dto.UserDTO;
+import com.ceos.bankids.exception.BadRequestException;
+import com.ceos.bankids.mapper.UserMapper;
+import com.ceos.bankids.repository.FamilyRepository;
+import com.ceos.bankids.repository.FamilyUserRepository;
+import com.ceos.bankids.repository.KidBackupRepository;
+import com.ceos.bankids.repository.KidRepository;
+import com.ceos.bankids.repository.ParentBackupRepository;
+import com.ceos.bankids.repository.ParentRepository;
+import com.ceos.bankids.repository.UserRepository;
+import com.ceos.bankids.service.ChallengeServiceImpl;
+import com.ceos.bankids.service.ChallengeUserServiceImpl;
+import com.ceos.bankids.service.ExpoNotificationServiceImpl;
+import com.ceos.bankids.service.FamilyServiceImpl;
+import com.ceos.bankids.service.FamilyUserServiceImpl;
+import com.ceos.bankids.service.JwtTokenServiceImpl;
+import com.ceos.bankids.service.KidBackupServiceImpl;
+import com.ceos.bankids.service.KidServiceImpl;
+import com.ceos.bankids.service.ParentBackupServiceImpl;
+import com.ceos.bankids.service.ParentServiceImpl;
+import com.ceos.bankids.service.SlackServiceImpl;
+import com.ceos.bankids.service.UserServiceImpl;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class UserControllerTest {
+
+    @Test
+    @DisplayName("유저 타입 패치 성공시, 결과 반환 하는지 확인")
+    public void testIfUserTypePatchSucceedReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        ExpoNotificationServiceImpl expoNotificationService = null;
+        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository, expoNotificationService);
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
+
+        // then
+        user.setBirthday("19990521");
+        user.setIsFemale(false);
+        user.setIsKid(true);
+        UserDTO userDTO = new UserDTO(user);
+        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 정보 이미 있어 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWhenAlreadyPatchedThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("body 없어서 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithoutArgumentsThrowNullPointerException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        // then
+        Assertions.assertThrows(NullPointerException.class, () -> {
+            userController.patchUserType(user, null);
+        });
+    }
+
+    @Test
+    @DisplayName("100세 초과 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithTooEarlyBirthdayThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("18880818", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("0세 미만 생년월일 입력으로 패치 실패시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithTooLateBirthdayThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("23450818", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("자녀 지정시, 자녀 row 생성 확인")
+    public void testIfKidInsertSucceedWhenUserTypePatchSucceed() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .savings(0L)
+            .user(user)
+            .level(1L)
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        Mockito.when(mockKidRepository.save(kid)).thenReturn(kid);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        ExpoNotificationServiceImpl expoNotificationService = null;
+        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository, expoNotificationService);
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.patchUserType(user, userTypeRequest);
+
+        // then
+        user.setBirthday("19990521");
+        user.setIsFemale(false);
+        user.setIsKid(true);
+        UserDTO userDTO = new UserDTO(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        ArgumentCaptor<Kid> kCaptor = ArgumentCaptor.forClass(Kid.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Mockito.verify(mockKidRepository, Mockito.times(1)).save(kCaptor.capture());
+
+        Assertions.assertEquals(user, uCaptor.getValue());
+        Assertions.assertEquals(kid, kCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+    }
+
+    @Test
+    @DisplayName("부모 지정시, 부모 row 생성 확인")
+    public void testIfParentInsertSucceedWhenUserTypePatchSucceed() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        Parent parent = Parent.builder()
+            .user(user)
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", true, false);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        Mockito.when(mockUserRepository.save(user)).thenReturn(user);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        Mockito.when(mockParentRepository.save(parent)).thenReturn(parent);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.patchUserType(user, userTypeRequest);
+
+        // then
+        user.setBirthday("19990521");
+        user.setIsFemale(true);
+        user.setIsKid(false);
+        UserDTO userDTO = new UserDTO(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        ArgumentCaptor<Parent> pCaptor = ArgumentCaptor.forClass(Parent.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Mockito.verify(mockParentRepository, Mockito.times(1)).save(pCaptor.capture());
+
+        Assertions.assertEquals(user, uCaptor.getValue());
+        Assertions.assertEquals(parent, pCaptor.getValue());
+
+        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+    }
+
+    @Test
+    @DisplayName("이미 타입을 선택한 유저 접근시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWhenAlreadyRegisteredThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("19990521", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(null));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("부모 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+    public void testIfParentTokenRefreshSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        TokenDTO tokenDTO = new TokenDTO(user);
+        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn(1L);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.patchRefreshToken(user);
+
+        // then
+        LoginDTO loginDTO = new LoginDTO(false, "aT", user.getProvider());
+        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+    }
+
+    @Test
+    @DisplayName("자녀 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+    public void testIfKidTokenRefreshSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        TokenDTO tokenDTO = new TokenDTO(user);
+        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn(1L);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.patchRefreshToken(user);
+
+        // then
+        LoginDTO loginDTO = new LoginDTO(true, "aT", 1L, user.getProvider());
+        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+    }
+
+    @Test
+    @DisplayName("타입 미선택 유저 토큰과 쿠키 정상 입력 시, 성공 결과 반환하는지 확인")
+    public void testIfUserTokenRefreshSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(null)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("token")
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        TokenDTO tokenDTO = new TokenDTO(user);
+        Mockito.when(jwtTokenServiceImpl.encodeJwtRefreshToken(1L)).thenReturn("rT");
+        Mockito.when(jwtTokenServiceImpl.encodeJwtToken(tokenDTO)).thenReturn("aT");
+        Mockito.when(jwtTokenServiceImpl.getUserIdFromJwtToken("rT")).thenReturn(1L);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.patchRefreshToken(user);
+
+        // then
+        LoginDTO loginDTO = new LoginDTO(null, "aT", user.getProvider());
+        Assertions.assertEquals(CommonResponse.onSuccess(loginDTO), result);
+    }
+
+
+    @Test
+    @DisplayName("부모 유저 정보 조회 성공 시, 부모 결과 반환하는지 확인")
+    public void testIfGetParentInfoSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+        Parent parent = Parent.builder()
+            .acceptedRequest(0L)
+            .totalRequest(0L)
+            .user(user)
+            .build();
+        user.setParent(parent);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.getUserInfo(user);
+
+        // then
+        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new ParentDTO(parent));
+        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
+    }
+
+    @Test
+    @DisplayName("자녀 유저 정보 조회 성공 시, 자녀 결과 반환하는지 확인")
+    public void testIfGetKidInfoSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.getUserInfo(user);
+
+        // then
+        MyPageDTO myPageDTO = new MyPageDTO(new UserDTO(user), new KidDTO(kid));
+        Assertions.assertEquals(CommonResponse.onSuccess(myPageDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 타입 선택 없이 유저 정보 조회 시, 에러 처리하는지 확인")
+    public void testIfGetUserInfoFailWithoutUserTypeThenThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(null)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("token")
+            .build();
+        Kid kid = Kid.builder()
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(1L)
+            .user(user)
+            .build();
+        user.setKid(kid);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.getUserInfo(user);
+        });
+    }
+
+    @Test
+    @DisplayName("유저 로그아웃 성공 시, null 반환하는지 확인")
+    public void testIfUserLogoutSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.patchUserLogout(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        user.setRefreshToken("");
+        user.setExpoToken("");
+        Assertions.assertEquals(user.getRefreshToken(), uCaptor.getValue().getRefreshToken());
+        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+    }
+
+    @Test
+    @DisplayName("가족 없는 부모 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfParentUserWithoutFamilyDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+        user1.setParent(parent);
+        ParentBackup parentBackup = ParentBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .acceptedRequest(user1.getParent().getAcceptedRequest())
+            .totalRequest(user1.getParent().getTotalRequest())
+            .build();
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+
+        ParentBackupRepository mockParentBackupRepository = Mockito.mock(
+            ParentBackupRepository.class);
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = new ParentBackupServiceImpl(
+            mockParentBackupRepository);
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("ParentBackup ", parentBackup.getId(),
+                withdrawalRequest.getMessage());
+        ExpoNotificationServiceImpl notificationService = Mockito.mock(
+            ExpoNotificationServiceImpl.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<ParentBackup> parentBackupCaptor = ArgumentCaptor.forClass(
+            ParentBackup.class);
+        Mockito.verify(mockParentBackupRepository, Mockito.times(1))
+            .save(parentBackupCaptor.capture());
+        Assertions.assertEquals(parentBackup, parentBackupCaptor.getValue());
+
+        ArgumentCaptor<Parent> parentCaptor = ArgumentCaptor.forClass(
+            Parent.class);
+        Mockito.verify(mockParentRepository, Mockito.times(1))
+            .delete(parentCaptor.capture());
+        Assertions.assertEquals(user1.getParent(), parentCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+    @Test
+    @DisplayName("가족 없는 자녀 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfKidUserWithoutFamilyDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        Kid kid = Kid.builder()
+            .id(1L)
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(0L)
+            .user(user1)
+            .build();
+        user1.setKid(kid);
+        KidBackup kidBackup = KidBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .savings(user1.getKid().getSavings())
+            .achievedChallenge(user1.getKid().getAchievedChallenge())
+            .totalChallenge(user1.getKid().getTotalChallenge())
+            .level(user1.getKid().getLevel())
+            .build();
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUserId(1L))
+            .thenReturn(Optional.ofNullable(null));
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+
+        KidBackupRepository mockKidBackupRepository = Mockito.mock(
+            KidBackupRepository.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
+        ParentBackupServiceImpl parentBackupService = null;
+        ExpoNotificationServiceImpl expoNotificationService = null;
+        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository, expoNotificationService);
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("KidBackup ", kidBackup.getId(),
+                withdrawalRequest.getMessage());
+        ExpoNotificationServiceImpl notificationService = Mockito.mock(
+            ExpoNotificationServiceImpl.class);
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<KidBackup> kidBackupCaptor = ArgumentCaptor.forClass(
+            KidBackup.class);
+        Mockito.verify(mockKidBackupRepository, Mockito.times(1))
+            .save(kidBackupCaptor.capture());
+        Assertions.assertEquals(kidBackup, kidBackupCaptor.getValue());
+
+        ArgumentCaptor<Kid> kidCaptor = ArgumentCaptor.forClass(
+            Kid.class);
+        Mockito.verify(mockKidRepository, Mockito.times(1))
+            .delete(kidCaptor.capture());
+        Assertions.assertEquals(user1.getKid(), kidCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+    @Test
+    @DisplayName("가족 있는 부모 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfParentUserWithFamilyDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+
+        Parent parent = Parent.builder().id(1L).acceptedRequest(0L).totalRequest(0L).user(user1)
+            .build();
+        user1.setParent(parent);
+        ParentBackup parentBackup = ParentBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .acceptedRequest(user1.getParent().getAcceptedRequest())
+            .totalRequest(user1.getParent().getTotalRequest())
+            .build();
+
+        Family family = Family.builder().id(1L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser2);
+        FamilyRequest familyRequest = new FamilyRequest("test");
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+
+        ParentBackupRepository mockParentBackupRepository = Mockito.mock(
+            ParentBackupRepository.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = new ParentBackupServiceImpl(
+            mockParentBackupRepository);
+        KidServiceImpl kidService = Mockito.mock(KidServiceImpl.class);
+        ParentServiceImpl parentService = new ParentServiceImpl(mockParentRepository);
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("ParentBackup ", parentBackup.getId(),
+                withdrawalRequest.getMessage());
+        ExpoNotificationServiceImpl notificationService = Mockito.mock(
+            ExpoNotificationServiceImpl.class);
+        ChallengeUserServiceImpl challengeUserService = Mockito.mock(
+            ChallengeUserServiceImpl.class);
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<FamilyUser> familyUserCaptor = ArgumentCaptor.forClass(
+            FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1))
+            .delete(familyUserCaptor.capture());
+        Assertions.assertEquals(familyUser1, familyUserCaptor.getValue());
+
+        ArgumentCaptor<ParentBackup> parentBackupCaptor = ArgumentCaptor.forClass(
+            ParentBackup.class);
+        Mockito.verify(mockParentBackupRepository, Mockito.times(1))
+            .save(parentBackupCaptor.capture());
+        Assertions.assertEquals(parentBackup, parentBackupCaptor.getValue());
+
+        ArgumentCaptor<Parent> parentCaptor = ArgumentCaptor.forClass(
+            Parent.class);
+        Mockito.verify(mockParentRepository, Mockito.times(1))
+            .delete(parentCaptor.capture());
+        Assertions.assertEquals(user1.getParent(), parentCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+    @Test
+    @DisplayName("가족 있는 자녀 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfKidUserWithFamilyDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+        User user2 = User.builder()
+            .id(2L)
+            .username("user2")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(false)
+            .refreshToken("token")
+            .build();
+
+        Kid kid = Kid.builder()
+            .id(1L)
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(0L)
+            .user(user1)
+            .build();
+        user1.setKid(kid);
+        KidBackup kidBackup = KidBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .savings(user1.getKid().getSavings())
+            .achievedChallenge(user1.getKid().getAchievedChallenge())
+            .totalChallenge(user1.getKid().getTotalChallenge())
+            .level(user1.getKid().getLevel())
+            .build();
+
+        Family family = Family.builder().id(1L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        FamilyUser familyUser2 = FamilyUser.builder().user(user2).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+        familyUserList.add(familyUser2);
+
+        FamilyRequest familyRequest = new FamilyRequest("test");
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+
+        KidBackupRepository mockKidBackupRepository = Mockito.mock(
+            KidBackupRepository.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
+        ParentBackupServiceImpl parentBackupService = null;
+        ExpoNotificationServiceImpl expoNotificationService = null;
+        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository, expoNotificationService);
+        ParentServiceImpl parentService = Mockito.mock(ParentServiceImpl.class);
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("KidBackup ", kidBackup.getId(),
+                withdrawalRequest.getMessage());
+        ExpoNotificationServiceImpl notificationService = Mockito.mock(
+            ExpoNotificationServiceImpl.class);
+        ChallengeUserServiceImpl challengeUserService = Mockito.mock(
+            ChallengeUserServiceImpl.class);
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<FamilyUser> familyUserCaptor = ArgumentCaptor.forClass(
+            FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1))
+            .delete(familyUserCaptor.capture());
+        Assertions.assertEquals(familyUser1, familyUserCaptor.getValue());
+
+        ArgumentCaptor<KidBackup> kidBackupCaptor = ArgumentCaptor.forClass(
+            KidBackup.class);
+        Mockito.verify(mockKidBackupRepository, Mockito.times(1))
+            .save(kidBackupCaptor.capture());
+        Assertions.assertEquals(kidBackup, kidBackupCaptor.getValue());
+
+        ArgumentCaptor<Kid> kidCaptor = ArgumentCaptor.forClass(
+            Kid.class);
+        Mockito.verify(mockKidRepository, Mockito.times(1))
+            .delete(kidCaptor.capture());
+        Assertions.assertEquals(user1.getKid(), kidCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+    @Test
+    @DisplayName("가족에 혼자인 유저 탈퇴 성공 시, 삭제 유저 반환하는지 확인")
+    public void testIfKidUserWithFamilyAloneDeleteAccountSucceedThenReturnResult() {
+        // given
+        User user1 = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .birthday("12345678")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .build();
+
+        Kid kid = Kid.builder()
+            .id(1L)
+            .savings(0L)
+            .achievedChallenge(0L)
+            .totalChallenge(0L)
+            .level(0L)
+            .user(user1)
+            .build();
+        user1.setKid(kid);
+        KidBackup kidBackup = KidBackup.builder()
+            .birthYear(user1.getBirthday().substring(0, 4))
+            .isKid(user1.getIsKid())
+            .savings(user1.getKid().getSavings())
+            .achievedChallenge(user1.getKid().getAchievedChallenge())
+            .totalChallenge(user1.getKid().getTotalChallenge())
+            .level(user1.getKid().getLevel())
+            .build();
+
+        Family family = Family.builder().id(1L).code("test").build();
+        FamilyUser familyUser1 = FamilyUser.builder().user(user1).family(family).build();
+        List<FamilyUser> familyUserList = new ArrayList<>();
+
+        FamilyRequest familyRequest = new FamilyRequest("test");
+        WithdrawalRequest withdrawalRequest = new WithdrawalRequest("탈퇴맨!");
+
+        // mock
+        FamilyUserRepository mockFamilyUserRepository = Mockito.mock(FamilyUserRepository.class);
+        Mockito.when(mockFamilyUserRepository.findByUser(user1))
+            .thenReturn(Optional.ofNullable(familyUser1));
+        Mockito.when(mockFamilyUserRepository.findByFamilyAndUserNot(family, user1))
+            .thenReturn(familyUserList);
+        FamilyRepository mockFamilyRepository = Mockito.mock(FamilyRepository.class);
+        Mockito.when(mockFamilyRepository.findById(1L)).thenReturn(Optional.ofNullable(family));
+
+        KidBackupRepository mockKidBackupRepository = Mockito.mock(
+            KidBackupRepository.class);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+        NotificationController mockNotificationController = Mockito.mock(
+            NotificationController.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = new FamilyServiceImpl(mockFamilyRepository);
+        FamilyUserServiceImpl familyUserService = new FamilyUserServiceImpl(
+            mockFamilyUserRepository);
+        ChallengeServiceImpl challengeService = Mockito.mock(ChallengeServiceImpl.class);
+        KidBackupServiceImpl kidBackupService = new KidBackupServiceImpl(mockKidBackupRepository);
+        ParentBackupServiceImpl parentBackupService = null;
+        ExpoNotificationServiceImpl expoNotificationService = null;
+        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository, expoNotificationService);
+        ParentServiceImpl parentService = Mockito.mock(ParentServiceImpl.class);
+        SlackServiceImpl slackService = Mockito.mock(SlackServiceImpl.class);
+        Mockito.doNothing().when(slackService)
+            .sendWithdrawalMessage("KidBackup ", kidBackup.getId(),
+                withdrawalRequest.getMessage());
+        ExpoNotificationServiceImpl notificationService = Mockito.mock(
+            ExpoNotificationServiceImpl.class);
+        ChallengeUserServiceImpl challengeUserService = Mockito.mock(
+            ChallengeUserServiceImpl.class);
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.deleteUserAccount(user1, withdrawalRequest);
+
+        ArgumentCaptor<FamilyUser> familyUserCaptor = ArgumentCaptor.forClass(
+            FamilyUser.class);
+        Mockito.verify(mockFamilyUserRepository, Mockito.times(1))
+            .delete(familyUserCaptor.capture());
+        Assertions.assertEquals(familyUser1, familyUserCaptor.getValue());
+
+        ArgumentCaptor<Family> familyCaptor = ArgumentCaptor.forClass(
+            Family.class);
+        Mockito.verify(mockFamilyRepository, Mockito.times(1))
+            .delete(familyCaptor.capture());
+        Assertions.assertEquals(family, familyCaptor.getValue());
+
+        ArgumentCaptor<KidBackup> kidBackupCaptor = ArgumentCaptor.forClass(
+            KidBackup.class);
+        Mockito.verify(mockKidBackupRepository, Mockito.times(1))
+            .save(kidBackupCaptor.capture());
+        Assertions.assertEquals(kidBackup, kidBackupCaptor.getValue());
+
+        ArgumentCaptor<Kid> kidCaptor = ArgumentCaptor.forClass(
+            Kid.class);
+        Mockito.verify(mockKidRepository, Mockito.times(1))
+            .delete(kidCaptor.capture());
+        Assertions.assertEquals(user1.getKid(), kidCaptor.getValue());
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(
+            User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1))
+            .delete(userCaptor.capture());
+        Assertions.assertEquals(user1, userCaptor.getValue());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new UserDTO(user1)), result);
+    }
+
+    @Test
+    @DisplayName("유저 엑스포 토큰 패치 성공 시, null 반환하는지 확인")
+    public void testIfUserExpoTokenPatchSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .expoToken("ExponentPushToken[dd]")
+            .build();
+        ExpoRequest expoRequest = new ExpoRequest("ExponentPushToken[dd]");
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse result = userController.patchExpoToken(user, expoRequest, response);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Assertions.assertEquals(user.getExpoToken(), uCaptor.getValue().getExpoToken());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(null), result);
+    }
+
+    @Test
+    @DisplayName("유저 공지 및 이벤트 알림 동의 시, 결과 반환하는지 확인")
+    public void testIfUserPatchNoticeOptInSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .expoToken("ExponentPushToken[dd]")
+            .noticeOptIn(false)
+            .serviceOptIn(false)
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse<OptInDTO> result = userController.patchNoticeOptIn(user);
+
+        user.setNoticeOptIn(true);
+        OptInDTO optInDTO = new OptInDTO(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Assertions.assertEquals(user.getNoticeOptIn(), uCaptor.getValue().getNoticeOptIn());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(optInDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 가족 활동 알림 동의 시, 결과 반환하는지 확인")
+    public void testIfUserPatchServiceOptInSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .expoToken("ExponentPushToken[dd]")
+            .noticeOptIn(false)
+            .serviceOptIn(false)
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse<OptInDTO> result = userController.patchServiceOptIn(user);
+
+        user.setServiceOptIn(true);
+        OptInDTO optInDTO = new OptInDTO(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Assertions.assertEquals(user.getServiceOptIn(), uCaptor.getValue().getServiceOptIn());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(optInDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 공지 및 이벤트 알림 비동의 시, 결과 반환하는지 확인")
+    public void testIfUserPatchNoticeOptOutSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .expoToken("ExponentPushToken[dd]")
+            .noticeOptIn(true)
+            .serviceOptIn(false)
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse<OptInDTO> result = userController.patchNoticeOptIn(user);
+
+        user.setNoticeOptIn(false);
+        OptInDTO optInDTO = new OptInDTO(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Assertions.assertEquals(user.getNoticeOptIn(), uCaptor.getValue().getNoticeOptIn());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(optInDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 가족 활동 알림 비동의 시, 결과 반환하는지 확인")
+    public void testIfUserPatchServiceOptOutSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .expoToken("ExponentPushToken[dd]")
+            .noticeOptIn(false)
+            .serviceOptIn(true)
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse<OptInDTO> result = userController.patchServiceOptIn(user);
+
+        user.setServiceOptIn(false);
+        OptInDTO optInDTO = new OptInDTO(user);
+
+        ArgumentCaptor<User> uCaptor = ArgumentCaptor.forClass(User.class);
+        Mockito.verify(mockUserRepository, Mockito.times(1)).save(uCaptor.capture());
+        Assertions.assertEquals(user.getServiceOptIn(), uCaptor.getValue().getServiceOptIn());
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(optInDTO), result);
+    }
+
+    @Test
+    @DisplayName("유저 생년월일이 유효하지 않아 실패 시, 에러 처리 되는지 확인")
+    public void testIfUserTypePatchFailWithInvalidBirthdayThrowBadRequestException() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(null)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(null)
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("23450231", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+        // then
+        Assertions.assertThrows(BadRequestException.class, () -> {
+            userController.patchUserType(user, userTypeRequest);
+        });
+    }
+
+    @Test
+    @DisplayName("유저 푸시 알림 동의 여부 조회 시, 결과 반환하는지 확인")
+    public void testIfGetUserOptInSucceedThenReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .isFemale(true)
+            .authenticationCode("code")
+            .provider("kakao")
+            .isKid(true)
+            .refreshToken("token")
+            .expoToken("ExponentPushToken[dd]")
+            .noticeOptIn(false)
+            .serviceOptIn(true)
+            .build();
+
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        KidServiceImpl kidService = null;
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse<OptInDTO> result = userController.getOptIn(user);
+
+        // then
+        Assertions.assertEquals(CommonResponse.onSuccess(new OptInDTO(user)), result);
+    }
+}


### PR DESCRIPTION
## 📝 PR Summary
- 매퍼로 리팩토링, 메소드 리네이밍 하면서 무너졌던 테스트 코드 전부 복원했습니다.
- 유저와 가족 Controller 기준으로 모든 API에 대하여 테스트 코드 작성했습니다.
- 유저 탈퇴, 가족 나가기에서 포함하는 돈길(Challenge, Progress, Comment) 삭제 관련 로직 + 부모, 자녀의 데이터 업데이트 로직 추가로 작성했습니다!
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
refactor/userAndFamilyTest
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] UserController 테스트 코드
- [x] FamilyController  테스트 코드
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#241 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
