### PR TITLE
refactor: 가족 조회하기 API 리스폰스 수정

### DIFF
--- a/src/main/java/com/ceos/bankids/mapper/FamilyMapper.java
+++ b/src/main/java/com/ceos/bankids/mapper/FamilyMapper.java
@@ -23,6 +23,7 @@ import com.ceos.bankids.service.ParentServiceImpl;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,14 +55,19 @@ public class FamilyMapper {
 
     @Transactional(readOnly = true)
     public FamilyDTO readFamily(User user) {
-        FamilyUser familyUser = familyUserService.findByUser(user);
-        Family family = familyUser.getFamily();
-        List<FamilyUser> familyUserList = familyUserService.getFamilyUserListExclude(family,
-            user);
+        Optional<FamilyUser> familyUser = familyUserService.findByUserNullable(user);
 
-        return new FamilyDTO(family, familyUserList.stream()
-            .map(FamilyUserDTO::new)
-            .collect(Collectors.toList()));
+        if (familyUser.isEmpty()) {
+            return new FamilyDTO(new Family(), List.of());
+        } else {
+            Family family = familyUser.get().getFamily();
+            List<FamilyUser> familyUserList = familyUserService.getFamilyUserListExclude(family,
+                user);
+
+            return new FamilyDTO(family, familyUserList.stream()
+                .map(FamilyUserDTO::new)
+                .collect(Collectors.toList()));
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest2.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/ChallengeControllerTest2.java
@@ -14,7 +14,6 @@ import com.ceos.bankids.repository.CommentRepository;
 import com.ceos.bankids.repository.ProgressRepository;
 import com.ceos.bankids.repository.TargetItemRepository;
 import com.ceos.bankids.service.ChallengeServiceImpl;
-import com.ceos.bankids.service.FamilyServiceImpl;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -112,9 +111,7 @@ public class ChallengeControllerTest2 {
             mockProgressRepository,
             mockCommentRepository
         );
-        FamilyServiceImpl familyService = new FamilyServiceImpl()
-
-
+//        FamilyServiceImpl familyService = new FamilyServiceImpl()
 
     }
 }

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -334,8 +334,8 @@ public class FamilyControllerTest {
     }
 
     @Test
-    @DisplayName("조회 시 기존 가족 있으나, 삭제되었을 때 에러 처리 하는지 확인")
-    public void testIfFamilyExistedButDeletedWhenGetThenThrowBadRequestException() {
+    @DisplayName("조회 시 기존 가족 없을 때, 빈 가족 정보 리턴 하는지 확인")
+    public void testIfFamilyNotExistThenReturnResult() {
         // given
         User user1 = User.builder()
             .id(1L)
@@ -393,10 +393,13 @@ public class FamilyControllerTest {
         );
         FamilyController familyController = new FamilyController(familyMapper);
 
+        CommonResponse<FamilyDTO> result = familyController.getFamily(user1);
+
         // then
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            familyController.getFamily(user1);
-        });
+        FamilyDTO familyDTO = FamilyDTO.builder()
+            .family(new Family())
+            .familyUserList(List.of()).build();
+        Assertions.assertEquals(CommonResponse.onSuccess(familyDTO), result);
     }
 
     @Test


### PR DESCRIPTION
## 📝 PR Summary
이전대로 가족이 없을 경우에도 빈 배열로 리스폰스를 반환합니다.
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
refactor/readFamily
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] mapper에서 가족이 존재할 때와 없을 때 분기 처리
- [x] 테스트 코드 정상 작동 확인 및 수정

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#245 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
