### PR TITLE
refactor: 아이들 리스트 조회하기 API 리스폰스 수정

### DIFF
--- a/src/main/java/com/ceos/bankids/mapper/FamilyMapper.java
+++ b/src/main/java/com/ceos/bankids/mapper/FamilyMapper.java
@@ -20,6 +20,7 @@ import com.ceos.bankids.service.FamilyServiceImpl;
 import com.ceos.bankids.service.FamilyUserServiceImpl;
 import com.ceos.bankids.service.KidServiceImpl;
 import com.ceos.bankids.service.ParentServiceImpl;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -76,16 +77,21 @@ public class FamilyMapper {
             throw new ForbiddenException(ErrorCode.KID_FORBIDDEN.getErrorCode());
         }
 
-        FamilyUser familyUser = familyUserService.findByUser(user);
-        List<FamilyUser> familyUserList = familyUserService.getFamilyUserList(
-            familyUser.getFamily(), user);
+        Optional<FamilyUser> familyUser = familyUserService.findByUserNullable(user);
 
-        List<KidListDTO> kidListDTOList = familyUserList.stream().map(FamilyUser::getUser)
-            .filter(User::getIsKid).map(KidListDTO::new).collect(
-                Collectors.toList());
-        Collections.sort(kidListDTOList, new KidListDTOComparator());
+        if (familyUser.isEmpty()) {
+            return new ArrayList<>();
+        } else {
+            List<FamilyUser> familyUserList = familyUserService.getFamilyUserList(
+                familyUser.get().getFamily(), user);
 
-        return kidListDTOList;
+            List<KidListDTO> kidListDTOList = familyUserList.stream().map(FamilyUser::getUser)
+                .filter(User::getIsKid).map(KidListDTO::new).collect(
+                    Collectors.toList());
+            Collections.sort(kidListDTOList, new KidListDTOComparator());
+
+            return kidListDTOList;
+        }
     }
 
     @Transactional

--- a/src/main/java/com/ceos/bankids/service/FamilyUserService.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyUserService.java
@@ -18,8 +18,6 @@ public interface FamilyUserService {
 
     public Optional<FamilyUser> findByUserNullable(User user);
 
-    public FamilyUser findByUser(User user);
-
     public FamilyUser findByUserAndCheckCode(User user, String code);
 
     public List<FamilyUser> getFamilyUserList(Family family, User user);

--- a/src/main/java/com/ceos/bankids/service/FamilyUserServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/FamilyUserServiceImpl.java
@@ -55,14 +55,6 @@ public class FamilyUserServiceImpl implements FamilyUserService {
 
     @Override
     @Transactional(readOnly = true)
-    public FamilyUser findByUser(User user) {
-        return familyUserRepository.findByUser(user)
-            .orElseThrow(
-                () -> new BadRequestException(ErrorCode.USER_NOT_IN_ANY_FAMILY.getErrorCode()));
-    }
-
-    @Override
-    @Transactional(readOnly = true)
     public FamilyUser findByUserAndCheckCode(User user, String code) {
         FamilyUser familyUser = familyUserRepository.findByUser(user).orElseThrow(
             () -> new BadRequestException(ErrorCode.USER_NOT_IN_ANY_FAMILY.getErrorCode()));

--- a/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/FamilyControllerTest.java
@@ -632,8 +632,8 @@ public class FamilyControllerTest {
     }
 
     @Test
-    @DisplayName("아이 조회 시 가족 없을 때, 에러 처리 하는지 확인")
-    public void testIfFamilyNotExistThenThrowBadRequestException() {
+    @DisplayName("아이 조회 시 가족 없을 때, 빈 리스트 결과 반환 하는지 확인")
+    public void testIfFamilyNotExistThenReturnEmptyListResult() {
         // given
         User user1 = User.builder()
             .id(1L)
@@ -674,10 +674,10 @@ public class FamilyControllerTest {
         );
         FamilyController familyController = new FamilyController(familyMapper);
 
+        CommonResponse<List<KidListDTO>> result = familyController.getFamilyKidList(user1);
+
         // then
-        Assertions.assertThrows(BadRequestException.class, () -> {
-            familyController.getFamilyKidList(user1);
-        });
+        Assertions.assertEquals(CommonResponse.onSuccess(new ArrayList()), result);
     }
 
     @Test


### PR DESCRIPTION
## 📝 PR Summary
가족이 없을 경우에도 빈 배열로 리스폰스를 반환합니다.
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
refactor/kidList
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x] mapper에서 가족이 존재할 때와 없을 때 분기 처리
- [x] 테스트 코드 정상 작동 확인 및 수정
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#248 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
