### PR TITLE
refactor: 돈길 저축 히스토리 위한 Delete 전략 변경

### DIFF
--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -2,7 +2,9 @@ package com.ceos.bankids.domain;
 
 import com.ceos.bankids.constant.ChallengeStatus;
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.sql.Timestamp;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -75,6 +77,10 @@ public class Challenge extends AbstractTimestamp {
 
     @Column(nullable = false)
     private String fileName;
+
+    @Column()
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss", timezone = "Asia/Seoul")
+    private Timestamp deleted_at;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "targetItemId", nullable = false)

--- a/src/main/java/com/ceos/bankids/domain/Challenge.java
+++ b/src/main/java/com/ceos/bankids/domain/Challenge.java
@@ -29,6 +29,8 @@ import lombok.ToString;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Setter
@@ -39,6 +41,8 @@ import org.hibernate.annotations.DynamicUpdate;
 @DynamicInsert
 @DynamicUpdate
 @ToString(exclude = {"progressList", "challengeUserList"})
+@Where(clause = "deleted_at is Null")
+@SQLDelete(sql = "UPDATE challenge SET deleted_at = CURRENT_TIMESTAMP where id = ?")
 public class Challenge extends AbstractTimestamp {
 
     @Id

--- a/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
+++ b/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
@@ -1,6 +1,8 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.sql.Timestamp;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -35,6 +37,10 @@ public class ChallengeUser extends AbstractTimestamp {
 
     @Column(nullable = false)
     private String member;
+
+    @Column()
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss", timezone = "Asia/Seoul")
+    private Timestamp deleted_at;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
+++ b/src/main/java/com/ceos/bankids/domain/ChallengeUser.java
@@ -16,6 +16,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
@@ -23,6 +25,8 @@ import lombok.Setter;
 @Table(name = "ChallengeUser")
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
+@Where(clause = "deleted_at is Null")
+@SQLDelete(sql = "UPDATE challenge_user SET deleted_at = CURRENT_TIMESTAMP where id = ?")
 public class ChallengeUser extends AbstractTimestamp {
 
     @Id

--- a/src/main/java/com/ceos/bankids/domain/Comment.java
+++ b/src/main/java/com/ceos/bankids/domain/Comment.java
@@ -1,7 +1,9 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.sql.Timestamp;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -38,6 +40,10 @@ public class Comment {
 
     @Column(nullable = false)
     private String content;
+
+    @Column()
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss", timezone = "Asia/Seoul")
+    private Timestamp deleted_at;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "challengeId", nullable = false)

--- a/src/main/java/com/ceos/bankids/domain/Comment.java
+++ b/src/main/java/com/ceos/bankids/domain/Comment.java
@@ -18,6 +18,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Getter
 @Setter
@@ -26,6 +28,8 @@ import org.hibernate.annotations.DynamicUpdate;
 @NoArgsConstructor
 @DynamicUpdate
 @EqualsAndHashCode(of = "id")
+@Where(clause = "deleted_at is Null")
+@SQLDelete(sql = "UPDATE comment SET deleted_at = CURRENT_TIMESTAMP where id = ?")
 public class Comment {
 
     @Id

--- a/src/main/java/com/ceos/bankids/domain/Progress.java
+++ b/src/main/java/com/ceos/bankids/domain/Progress.java
@@ -17,6 +17,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
@@ -25,6 +27,8 @@ import org.hibernate.annotations.DynamicInsert;
 @NoArgsConstructor
 @DynamicInsert
 @EqualsAndHashCode(of = "id")
+@Where(clause = "deleted_at is Null")
+@SQLDelete(sql = "UPDATE progress SET deleted_at = CURRENT_TIMESTAMP where id = ?")
 public class Progress extends AbstractTimestamp {
 
     @Id
@@ -33,7 +37,7 @@ public class Progress extends AbstractTimestamp {
 
     @Column(nullable = false)
     private Long weeks;
-    
+
     @Column()
     @ColumnDefault("false") //default value: false
     private Boolean isAchieved;

--- a/src/main/java/com/ceos/bankids/domain/Progress.java
+++ b/src/main/java/com/ceos/bankids/domain/Progress.java
@@ -1,6 +1,8 @@
 package com.ceos.bankids.domain;
 
 import com.ceos.bankids.exception.BadRequestException;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.sql.Timestamp;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -41,6 +43,10 @@ public class Progress extends AbstractTimestamp {
     @Column()
     @ColumnDefault("false") //default value: false
     private Boolean isAchieved;
+
+    @Column()
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd hh:mm:ss", timezone = "Asia/Seoul")
+    private Timestamp deleted_at;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "challengeId", nullable = false)

--- a/src/main/java/com/ceos/bankids/service/ExpoNotificationServiceImpl.java
+++ b/src/main/java/com/ceos/bankids/service/ExpoNotificationServiceImpl.java
@@ -47,6 +47,7 @@ public class ExpoNotificationServiceImpl implements ExpoNotificationService {
 
     private final NotificationRepository notificationRepository;
 
+    // Pagenation
     @Transactional
     @Override
     public NotificationListDTO readNotificationList(User user, Long lastId) {


### PR DESCRIPTION
## 📝 PR Summary

<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->
* 돈길 관련 (challenge, challengeUser, comment, progress ... ) deleted_at 컬럼 추가

#### 🌲 Working Branch

<!-- 예시) hotfix/price_comma -->
* refactor/challengeDeleteCoulmn

#### 🌲 TODOs

<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->
* 돈길 저축 히스토리 API 작성

### Related Issues

<!-- 예시) * resolves #71 -->
#254
<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
