### PR TITLE
refactor: 생년월일 미입력 허용

### DIFF
--- a/src/main/java/com/ceos/bankids/mapper/UserMapper.java
+++ b/src/main/java/com/ceos/bankids/mapper/UserMapper.java
@@ -67,21 +67,23 @@ public class UserMapper {
             throw new BadRequestException(ErrorCode.USER_ALREADY_HAS_TYPE.getErrorCode());
         }
 
-        // 날짜 자체가 유효한지 검사
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
-        dateFormat.setLenient(false);
-        try {
-            dateFormat.parse(userTypeRequest.getBirthday());
-        } catch (ParseException e) {
-            throw new BadRequestException(ErrorCode.INVALID_BIRTHDAY.getErrorCode());
-        }
+        // 날짜가 입력됐다면 유효한지 검사
+        if (userTypeRequest.getBirthday() != "") {
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
+            dateFormat.setLenient(false);
+            try {
+                dateFormat.parse(userTypeRequest.getBirthday());
+            } catch (ParseException e) {
+                throw new BadRequestException(ErrorCode.INVALID_BIRTHDAY.getErrorCode());
+            }
 
-        // 가입이 유효한 범위의 날짜인지 검사
-        Calendar cal = Calendar.getInstance();
-        Integer currYear = cal.get(Calendar.YEAR);
-        Integer birthYear = Integer.parseInt(userTypeRequest.getBirthday()) / 10000;
-        if (birthYear >= currYear || birthYear <= currYear - 100) {
-            throw new BadRequestException(ErrorCode.INVALID_BIRTHDAY.getErrorCode());
+            // 가입이 유효한 범위의 날짜인지 검사
+            Calendar cal = Calendar.getInstance();
+            Integer currYear = cal.get(Calendar.YEAR);
+            Integer birthYear = Integer.parseInt(userTypeRequest.getBirthday()) / 10000;
+            if (birthYear >= currYear || birthYear <= currYear - 100) {
+                throw new BadRequestException(ErrorCode.INVALID_BIRTHDAY.getErrorCode());
+            }
         }
 
         UserDTO userDTO = userService.updateUserType(user, userTypeRequest);

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -55,8 +55,8 @@ import org.mockito.Mockito;
 public class UserControllerTest {
 
     @Test
-    @DisplayName("유저 타입 패치 성공시, 결과 반환 하는지 확인")
-    public void testIfUserTypePatchSucceedReturnResult() {
+    @DisplayName("생년월일 입력한 유저 타입 패치 성공시, 결과 반환 하는지 확인")
+    public void testIfUserTypePatchWithBirthdaySucceedReturnResult() {
         // given
         User user = User.builder()
             .id(1L)
@@ -109,6 +109,65 @@ public class UserControllerTest {
         user.setIsFemale(false);
         user.setIsKid(true);
         UserDTO userDTO = new UserDTO(user);
+        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
+    }
+
+    @Test
+    @DisplayName("생년월일 입력하지 않은 유저 타입 패치 성공시, 결과 반환 하는지 확인")
+    public void testIfUserTypePatchWithoutBirthdaySucceedReturnResult() {
+        // given
+        User user = User.builder()
+            .id(1L)
+            .username("user1")
+            .authenticationCode("code")
+            .provider("kakao")
+            .refreshToken("token")
+            .build();
+        UserTypeRequest userTypeRequest = new UserTypeRequest("", false, true);
+        UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
+        Mockito.when(mockUserRepository.findById(1L))
+            .thenReturn(Optional.ofNullable(user));
+        KidRepository mockKidRepository = Mockito.mock(KidRepository.class);
+        ParentRepository mockParentRepository = Mockito.mock(ParentRepository.class);
+        JwtTokenServiceImpl jwtTokenServiceImpl = Mockito.mock(JwtTokenServiceImpl.class);
+
+        // when
+        UserServiceImpl userService = new UserServiceImpl(mockUserRepository);
+        FamilyServiceImpl familyService = null;
+        FamilyUserServiceImpl familyUserService = null;
+        ChallengeServiceImpl challengeService = null;
+        KidBackupServiceImpl kidBackupService = null;
+        ParentBackupServiceImpl parentBackupService = null;
+        ExpoNotificationServiceImpl expoNotificationService = null;
+        KidServiceImpl kidService = new KidServiceImpl(mockKidRepository, expoNotificationService);
+        ParentServiceImpl parentService = null;
+        SlackServiceImpl slackService = null;
+        ExpoNotificationServiceImpl notificationService = null;
+        ChallengeUserServiceImpl challengeUserService = null;
+        UserMapper userMapper = new UserMapper(
+            userService,
+            familyService,
+            familyUserService,
+            challengeService,
+            kidBackupService,
+            parentBackupService,
+            kidService,
+            parentService,
+            slackService,
+            notificationService,
+            jwtTokenServiceImpl,
+            challengeUserService
+        );
+        UserController userController = new UserController(userMapper);
+
+        CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
+
+        // then
+        user.setBirthday("");
+        user.setIsFemale(false);
+        user.setIsKid(true);
+        UserDTO userDTO = new UserDTO(user);
+        Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
         Assertions.assertEquals(CommonResponse.onSuccess(userDTO), result);
     }
 


### PR DESCRIPTION
## 📝 PR Summary
생년월일을 입력하지 않고도 가입이 가능해짐에 따라 생년월일 미입력 허용
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
refactor/birthday
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x]  Mapper에서 생년월일 유효성 검사 로직 변경
- [x] 테스트 코드 작성
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#258
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
