### PR TITLE
refactor: 미가입 생년월일 빈 문자열 대신 99999999로 변경

### DIFF
--- a/src/main/java/com/ceos/bankids/mapper/UserMapper.java
+++ b/src/main/java/com/ceos/bankids/mapper/UserMapper.java
@@ -68,7 +68,7 @@ public class UserMapper {
         }
 
         // 날짜가 입력됐다면 유효한지 검사
-        if (userTypeRequest.getBirthday() != "") {
+        if (userTypeRequest.getBirthday() != "99999999") {
             SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd");
             dateFormat.setLenient(false);
             try {

--- a/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
+++ b/src/test/java/com/ceos/bankids/unit/controller/UserControllerTest.java
@@ -123,7 +123,7 @@ public class UserControllerTest {
             .provider("kakao")
             .refreshToken("token")
             .build();
-        UserTypeRequest userTypeRequest = new UserTypeRequest("", false, true);
+        UserTypeRequest userTypeRequest = new UserTypeRequest("99999999", false, true);
         UserRepository mockUserRepository = Mockito.mock(UserRepository.class);
         Mockito.when(mockUserRepository.findById(1L))
             .thenReturn(Optional.ofNullable(user));
@@ -163,7 +163,7 @@ public class UserControllerTest {
         CommonResponse<UserDTO> result = userController.patchUserType(user, userTypeRequest);
 
         // then
-        user.setBirthday("");
+        user.setBirthday("99999999");
         user.setIsFemale(false);
         user.setIsKid(true);
         UserDTO userDTO = new UserDTO(user);


### PR DESCRIPTION
## 📝 PR Summary
미가입 생년월일 빈 문자열 대신 99999999로 변경
<!-- 예시) 상품 가격 천단위 humanize intcomma 적용 -->

#### 🌲 Working Branch
refactor/birthday
<!-- 예시) hotfix/price_comma -->

#### 🌲 TODOs
- [x]  미가입 생년월일 빈 문자열 대신 99999999로 변경
- [x]  테스트 코드 변경
<!-- 예시) * 상품 스토어 리스트 가격 천단위 표기 적용 -->

### Related Issues
#261 
<!-- 예시) * resolves #71 -->

<!-- 예시) * @24siefil 결제와 직결되는 부분이라 merge 후 상품 상세, 마이페이지-장바구니 파트 테스트 바랍니다 -->
